### PR TITLE
Reorder python imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,8 @@ repos:
     -   id: mypy
         files: ^(python/src/|python/tests/)
         args: []
+-   repo: https://github.com/asottile/reorder_python_imports
+    rev: v1.6.1
+    hooks:
+    -   id: reorder-python-imports
+        args: ['--application-directories=python:python/src', --py3-plus]

--- a/python/tests/test_pdb.py
+++ b/python/tests/test_pdb.py
@@ -1,6 +1,7 @@
 import os
 
-from posterior_db import Posterior, PosteriorDatabase
+from posterior_db import Posterior
+from posterior_db import PosteriorDatabase
 
 
 def test_posterior_database():


### PR DESCRIPTION
Add pre-commit check that reorders python imports if needed. This is also checked with CI.