### PR TITLE
Fix CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@ repos:
 #     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
+        exclude: ^README.md
 -   repo: https://github.com/psf/black
     rev: 19.3b0
     hooks:

--- a/rpackage/DESCRIPTION
+++ b/rpackage/DESCRIPTION
@@ -3,12 +3,12 @@ Type: Package
 Title: The Posterior Database R functionality
 Version: 0.1
 Date: 2019-09-26
-Authors@R: c(person("Mans", "Magnusson", email = "mans.magnusson@gmail.com", 
+Authors@R: c(person("Mans", "Magnusson", email = "mans.magnusson@gmail.com",
                     role = c("cre", "aut")),
              person("Paul-Christian", "Bürkner", email = "paul.buerkner@gmail.com",
                     role = c("aut")))
 Maintainer: Mans Magnusson <mans.magnusson@gmail.com>
-Description: R functionality of easy access of different posteriors (i.e. 
+Description: R functionality of easy access of different posteriors (i.e.
   combination of data and models).
 License: GPL (>= 2)
 RoxygenNote: 6.1.1


### PR DESCRIPTION
This strips trailing whitespace from `rpackage/DESCRIPTION` and removes the trailing whitespace check from `README.md`. `README.Rmd` is still checked for trailing whitespace. 