### PR TITLE
Add some tests for database integrity

### DIFF
--- a/python/tests/integrity_tests/helpers.py
+++ b/python/tests/integrity_tests/helpers.py
@@ -1,0 +1,40 @@
+import collections
+
+import pytest
+
+
+def _ensure_all_distinct(dct, error_message_callable):
+    reverse_mapping = collections.defaultdict(list)
+    for key, val in dct.items():
+        reverse_mapping[val].append(key)
+
+    duplicates = {k: v for (k, v) in reverse_mapping.items() if len(v) > 1}
+
+    if len(duplicates) > 0:
+        error_msgs = "\n".join(
+            [
+                error_message_callable(duplicate_val, duplicate_names)
+                for (duplicate_val, duplicate_names) in duplicates.items()
+            ]
+        )
+        pytest.fail(error_msgs)
+
+
+def ensure_model_codes_are_distinct(dct):
+    def error_msg(code_path, names):
+        return f"""Models {", ".join(names)} had the same stan code: {code_path}"""
+
+    __tracebackhide__ = True
+
+    _ensure_all_distinct(dct, error_msg)
+
+
+def ensure_dataset_paths_are_distinct(dct):
+    def error_msg(data_file_path, names):
+        return (
+            f"""Datasets {", ".join(names)} had the same data file: {data_file_path}"""
+        )
+
+    __tracebackhide__ = True
+
+    _ensure_all_distinct(dct, error_msg)

--- a/python/tests/integrity_tests/test_integrity.py
+++ b/python/tests/integrity_tests/test_integrity.py
@@ -1,0 +1,32 @@
+import os
+
+from . import helpers
+from posteriordb import Dataset
+from posteriordb import Model
+from posteriordb import PosteriorDatabase
+
+
+def get_posterior_db():
+    path = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+    pdb = PosteriorDatabase(path)
+    return pdb
+
+
+def test_models_dont_have_same_model_code():
+    pdb = get_posterior_db()
+
+    model_code_paths = {
+        model.name: model.stan_code_file_path() for model in pdb.models()
+    }
+
+    helpers.ensure_model_codes_are_distinct(model_code_paths)
+
+
+def test_datasets_dont_have_same_data():
+    pdb = get_posterior_db()
+
+    data_names = pdb.dataset_names()
+
+    data_file_paths = {name: pdb.get_dataset_path(name) for name in data_names}
+
+    helpers.ensure_dataset_paths_are_distinct(data_file_paths)


### PR DESCRIPTION
This PR adds tests for checking that
- No two models have the same stan code file
- No two datasets have the same data file

For example if in https://github.com/MansMeg/posteriordb/blob/master/content/models/info/8_schools_noncentered.info.json I change the stan code from `content/models/stan/8_schools_noncentered.stan` to `content/models/stan/8_schools_centered.stan` then these tests will fail because the models `8_schools_centered` and `8_schools_noncentered` have the same stan code file.

Related to #66 