### PR TITLE
Improved python api

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -18,9 +18,10 @@ The included database contains convenience functions to access data, model code 
 First we create the posterior database to use, here the cloned posterior database.
 
 ```python
->>> from posterior_db import PosteriorDatabase, Posterior
+>>> from posteriordb import PosteriorDatabase
 >>> import os
->>> my_pdb = PosteriorDatabase(os.getcwd())
+>>> pdb_path = os.path.join(os.getcwd(), "posterior_database")
+>>> my_pdb = PosteriorDatabase(pdb_path)
 ```
 
 The above code requires that your working directory is in the main folder of your copy
@@ -65,25 +66,43 @@ In the same fashion, we can list data and models included in the database as
 
 The posterior's name is made up of the data and model fitted
 to the data. Together, these two uniquely define a posterior distribution.
-To access a posterior object we can use the model name.
+To access a posterior object we can use the posterior name.
 
 ```python
->>> po = Posterior("eight_schools-eight_schools_centered", my_pdb)
+>>> posterior = my_pdb.posterior("eight_schools-eight_schools_centered")
 ```
 
-From the posterior object, we can access data, model code (i.e., Stan code
-in this case) and a lot of other useful information.
+From the posterior we can access the dataset and the model
 
 ```python
->>> po.dataset()
+>>> model = posterior.model
+>>> data = posterior.data
+```
 
-{'J': 8,
- 'y': [28, 8, -3, 7, -1, 1, 18, 12],
- 'sigma': [15, 10, 16, 11, 9, 11, 10, 18]}
+We can also access the names of posteriors, models and datasets.
 
->>> sc = po.stan_code()
->>> print(sc)
+```python
+>>> posterior.name
+"eight_schools-eight_schools_centered"
 
+>>> model.name
+"eight_schools_centered"
+
+>>> data.name
+"eight_schools"
+
+```
+
+We can access the same model and dataset also directly from the posterior database
+```python
+>>> model = my_pdb.model("eight_schools_centered")
+>>> data = my_pdb.data("eight_schools")
+```
+
+From the model we can access model code and information about the model
+
+```python
+>>> model.code("stan")
 data {
   int <lower=0> J; // number of schools
   real y[J]; // estimated treatment
@@ -101,55 +120,45 @@ model {
   mu ~ normal(0, 5);
 }
 
-```
-
-We can also access the paths to data and model code files
-
-```python
->>> dfp = po.dataset_file_path()
->>> dfp
-'/tmp/tmpx16edu0w'
-
->>> scfp = po.stan_code_file_path()
->>> scfp
-
+>>> model.code_file_path("stan")
 '/home/eero/posterior_database/content/models/stan/eight_schools_centered.stan'
-```
 
-We can also access information regarding the model and the data used to compute the posterior.
-
-```python
->>> po.data_info
-
-{'keywords': ['bda3_example'],
- 'description': 'A study for the Educational Testing Service to analyze the effects of\nspecial coaching programs on test scores. See Gelman et. al. (2014), Section 5.5 for details.',
- 'urls': ['http://www.stat.columbia.edu/~gelman/arm/examples/schools'],
- 'title': 'The 8 schools dataset of Rubin (1981)',
- 'references': ['rubin1981estimation', 'gelman2013bayesian'],
- 'data_file': 'content/datasets/data/eight_schools.json',
- 'added_by': 'Mans Magnusson',
- 'added_date': '2019-08-12'}
-
-
->>> po.model_info
-
+>>> model.information
 {'keywords': ['bda3_example', 'hiearchical'],
  'description': 'A centered hiearchical model for the 8 schools example of Rubin (1981)',
  'urls': ['http://www.stat.columbia.edu/~gelman/arm/examples/schools'],
  'title': 'A centered hiearchical model for 8 schools',
  'references': ['rubin1981estimation', 'gelman2013bayesian'],
- 'model_code': {'stan': 'content/models/stan/eight_schools_centered.stan'},
  'added_by': 'Mans Magnusson',
  'added_date': '2019-08-12'}
-
 ```
-
 Note that the references are referencing to BibTeX items that can be found in `content/references/references.bib`.
+
+From the dataset we can access the data values and information about it
+
+```python
+>>> data.values()
+{'J': 8,
+ 'y': [28, 8, -3, 7, -1, 1, 18, 12],
+ 'sigma': [15, 10, 16, 11, 9, 11, 10, 18]}
+
+>>> data.file_path()
+'/tmp/tmpx16edu0w'
+
+>>> data.information
+{'keywords': ['bda3_example'],
+ 'description': 'A study for the Educational Testing Service to analyze the effects of\nspecial coaching programs on test scores. See Gelman et. al. (2014), Section 5.5 for details.',
+ 'urls': ['http://www.stat.columbia.edu/~gelman/arm/examples/schools'],
+ 'title': 'The 8 schools dataset of Rubin (1981)',
+ 'references': ['rubin1981estimation', 'gelman2013bayesian'],
+ 'added_by': 'Mans Magnusson',
+ 'added_date': '2019-08-12'}
+```
 
 To access gold standard posterior draws we can use `gold_standard` as follows (NOTE not implemented yet).
 
 ```python
-> gs = po.gold_standard()
+> gs = posterior.gold_standard()
 
 NOT_IMPLEMENTED_YET
 ```

--- a/python/src/posteriordb/__init__.py
+++ b/python/src/posteriordb/__init__.py
@@ -1,4 +1,1 @@
-from .dataset import Dataset
-from .model import Model
-from .posterior import Posterior
 from .posterior_database import PosteriorDatabase

--- a/python/src/posteriordb/dataset.py
+++ b/python/src/posteriordb/dataset.py
@@ -4,23 +4,25 @@ import tempfile
 from zipfile import ZipFile
 
 from .posterior_database import PosteriorDatabase
+from .util import drop_keys
 
 
 class Dataset:
     def __init__(self, name: str, posterior_db: PosteriorDatabase):
         self.name = name
         self.posterior_db = posterior_db
-        self.data_info = self.posterior_db.get_data_info(name=self.name)
+        full_information = self.posterior_db.get_data_info(name=self.name)
+        self.information = drop_keys(full_information, "data_file")
 
-    def dataset_file_path(self):
-        data = self.dataset()
+    def file_path(self):
+        data = self.values()
         # make a temp file with unzipped data
         with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
             json.dump(data, f)
             file_name = f.name
         return file_name
 
-    def dataset(self):
+    def values(self):
         # unzip the file on the fly
         # return contents
         path = self.posterior_db.get_dataset_path(self.name)

--- a/python/src/posteriordb/model.py
+++ b/python/src/posteriordb/model.py
@@ -1,33 +1,35 @@
 import os
 
 from .posterior_database import PosteriorDatabase
+from .util import drop_keys
 
 
 class Model:
     def __init__(self, name: str, posterior_db: PosteriorDatabase):
         self.name = name
         self.posterior_db = posterior_db
-        self.model_info = self.posterior_db.get_model_info(name=self.name)
+        full_model_info = self.posterior_db.get_model_info(name=self.name)
+        self.information = drop_keys(full_model_info, "model_code")
 
-    def model_code_file_path(self, framework: str):
+    def code_file_path(self, framework: str):
         """
         Returns filepath to model code file for `framework`
         """
         # TODO assert that framework is a valid framework for this model
         return self.posterior_db.get_model_code_path(self.name, framework)
 
-    def model_code(self, framework: str):
+    def code(self, framework: str):
         """
         Returns model code for `framework` as a string
         """
-        file_path = self.model_code_file_path(framework)
+        file_path = self.code_file_path(framework)
         with open(file_path) as f:
             contents = f.read()
 
         return contents
 
     def stan_code(self):
-        return self.model_code("stan")
+        return self.code("stan")
 
     def stan_code_file_path(self):
-        return self.model_code_file_path("stan")
+        return self.code_file_path("stan")

--- a/python/src/posteriordb/posterior.py
+++ b/python/src/posteriordb/posterior.py
@@ -16,7 +16,7 @@ class Posterior:
         self.data = Dataset(self.posterior_info["data_name"], posterior_db)
 
     def model_code_file_path(self, framework: str):
-        return self.model.model_code_file_path(framework)
+        return self.model.code_file_path(framework)
 
     def stan_code_file_path(self):
         return self.model.stan_code_file_path()
@@ -25,21 +25,13 @@ class Posterior:
         return self.model.stan_code()
 
     def model_code(self, framework: str):
-        return self.model.model_code(framework)
+        return self.model.code(framework)
 
-    @property
-    def model_info(self):
-        return self.model.model_info
+    def data_values(self):
+        return self.data.values()
 
-    @property
-    def data_info(self):
-        return self.data.data_info
-
-    def dataset(self):
-        return self.data.dataset()
-
-    def dataset_file_path(self):
-        return self.data.dataset_file_path()
+    def data_file_path(self):
+        return self.data.file_path()
 
     def gold_standard(self):
         # gold_standard_file = self.posterior_info["gold_standard"]

--- a/python/src/posteriordb/posterior.py
+++ b/python/src/posteriordb/posterior.py
@@ -15,24 +15,6 @@ class Posterior:
 
         self.data = Dataset(self.posterior_info["data_name"], posterior_db)
 
-    def model_code_file_path(self, framework: str):
-        return self.model.code_file_path(framework)
-
-    def stan_code_file_path(self):
-        return self.model.stan_code_file_path()
-
-    def stan_code(self):
-        return self.model.stan_code()
-
-    def model_code(self, framework: str):
-        return self.model.code(framework)
-
-    def data_values(self):
-        return self.data.values()
-
-    def data_file_path(self):
-        return self.data.file_path()
-
     def gold_standard(self):
         # gold_standard_file = self.posterior_info["gold_standard"]
         raise NotImplementedError()

--- a/python/src/posteriordb/posterior_database.py
+++ b/python/src/posteriordb/posterior_database.py
@@ -36,6 +36,24 @@ class PosteriorDatabase:
         self.path = path
         # TODO assert that path is a valid posterior database
 
+    def posterior(self, name):
+        # inline import needed to avoid import loop
+        from .posterior import Posterior
+
+        return Posterior(name, self)
+
+    def model(self, name):
+        # inline import needed to avoid import loop
+        from .model import Model
+
+        return Model(name, self)
+
+    def data(self, name):
+        # inline import needed to avoid import loop
+        from .dataset import Dataset
+
+        return Dataset(name, self)
+
     def posterior_info_path(self, name: str):
         file_path = os.path.join(self.path, "posteriors", name + ".json")
         return file_path

--- a/python/src/posteriordb/util.py
+++ b/python/src/posteriordb/util.py
@@ -1,0 +1,7 @@
+def drop_keys(dct, keys_to_drop):
+    if not isinstance(keys_to_drop, list):
+        keys_to_drop = [keys_to_drop]
+
+    new_dct = {k: v for (k, v) in dct.items() if k not in keys_to_drop}
+
+    return new_dct

--- a/python/tests/integrity_tests/test_integrity.py
+++ b/python/tests/integrity_tests/test_integrity.py
@@ -1,8 +1,6 @@
 import os
 
 from . import helpers
-from posteriordb import Dataset
-from posteriordb import Model
 from posteriordb import PosteriorDatabase
 
 

--- a/python/tests/test_pdb.py
+++ b/python/tests/test_pdb.py
@@ -23,16 +23,31 @@ def test_posterior_database():
     for name in posterior_names:
         posterior = Posterior(name, pdb)
 
-        assert posterior.dataset() is not None
-        assert posterior.dataset_file_path() is not None
+        # test posterior methods
+        assert posterior.data_file_path() is not None
+        assert posterior.data_values() is not None
         assert posterior.model_code("stan") is not None
         assert posterior.model_code_file_path("stan") is not None
         assert posterior.stan_code() is not None
         assert posterior.stan_code_file_path() is not None
-        assert posterior.model.stan_code_file_path() is not None
-        assert posterior.model_info is not None
-        assert posterior.data_info is not None
 
+        # test dataset methods
+        data = posterior.data
+
+        assert data.values() is not None
+        assert data.file_path() is not None
+
+        assert data.information is not None
+        # test model methods
+
+        model = posterior.model
+
+        assert model.code("stan") is not None
+        assert model.code_file_path("stan") is not None
+        assert model.stan_code() is not None
+        assert model.stan_code_file_path() is not None
+
+        assert model.information is not None
     posteriors = list(pdb.posteriors())
     assert len(posteriors) > 0
 

--- a/python/tests/test_pdb.py
+++ b/python/tests/test_pdb.py
@@ -1,6 +1,5 @@
 import os
 
-from posteriordb import Posterior
 from posteriordb import PosteriorDatabase
 
 
@@ -21,8 +20,9 @@ def test_posterior_database():
     assert len(posterior_names) > 0
 
     for name in posterior_names:
-        posterior = Posterior(name, pdb)
+        posterior = pdb.posterior(name)
 
+        assert posterior.name is not None
         # test posterior methods
         assert posterior.data_file_path() is not None
         assert posterior.data_values() is not None
@@ -33,14 +33,21 @@ def test_posterior_database():
 
         # test dataset methods
         data = posterior.data
+        assert data.name is not None
 
         assert data.values() is not None
         assert data.file_path() is not None
 
         assert data.information is not None
-        # test model methods
 
+        # test that pdb.data works
+        data2 = pdb.data(data.name)
+        assert data2 is not None
+
+        # test model methods
         model = posterior.model
+
+        assert model.name is not None
 
         assert model.code("stan") is not None
         assert model.code_file_path("stan") is not None
@@ -48,6 +55,11 @@ def test_posterior_database():
         assert model.stan_code_file_path() is not None
 
         assert model.information is not None
+
+        # test that pdb.model works
+        model2 = pdb.model(model.name)
+        assert model2 is not None
+
     posteriors = list(pdb.posteriors())
     assert len(posteriors) > 0
 

--- a/python/tests/test_pdb.py
+++ b/python/tests/test_pdb.py
@@ -23,13 +23,6 @@ def test_posterior_database():
         posterior = pdb.posterior(name)
 
         assert posterior.name is not None
-        # test posterior methods
-        assert posterior.data_file_path() is not None
-        assert posterior.data_values() is not None
-        assert posterior.model_code("stan") is not None
-        assert posterior.model_code_file_path("stan") is not None
-        assert posterior.stan_code() is not None
-        assert posterior.stan_code_file_path() is not None
 
         # test dataset methods
         data = posterior.data


### PR DESCRIPTION
Fixes #53 

There's some differences to the API that was described in #53
- `data.file()` is called here `data.file_path()` (same for `code_file_path` etc). This is because `file` is a builtin type in python and `data.file()` gets syntax highlighted funnily even though it is a valid method name. I think `file` would be ideologically better but `file_path` is more pragmatic in this situation and thus I chose to use it.
- I went with `data` over `dataset` as that's what the R API seems to be using now and also I don't see any downside to calling it `data` over `dataset`. However the class is still called `Dataset` internally but changing that won't affect the user facing API so I can do that a bit later.
- I ended up dropping the shortcut methods like `posterior.data_file_path()`, instead `posterior.data.file_path()` should be used. I feel like the shortcuts don't really add anything (in this case the difference is `_` vs `.`) and it's more clear if there's only one way to do something. It also makes the library simpler, which is always good.