### PR TITLE
WIP: Add test for checking that generated readme is up-to-date

### DIFF
--- a/rpackage/DESCRIPTION
+++ b/rpackage/DESCRIPTION
@@ -25,4 +25,5 @@ Suggests:
   git2r,
   remotes,
   rstan,
-  testthat
+  testthat,
+  rmarkdown

--- a/rpackage/tests/testthat/test-readme.R
+++ b/rpackage/tests/testthat/test-readme.R
@@ -2,8 +2,8 @@
 context("test-readme")
 
 test_that("Check that the generated README is up-to-date", {
-  current_readme <- readLines("../../../README.md")
-  rmarkdown::render("../../../README.Rmd")
-  generated_readme <- readLines("../../../README.md")
+  current_readme <- readLines("../../../../README.md")
+  rmarkdown::render("../../../../README.Rmd")
+  generated_readme <- readLines("../../../../README.md")
   expect_equal(current_readme, generated_readme)
 })

--- a/rpackage/tests/testthat/test-readme.R
+++ b/rpackage/tests/testthat/test-readme.R
@@ -2,8 +2,8 @@
 context("test-readme")
 
 test_that("Check that the generated README is up-to-date", {
-  current_readme <- read.file("README.md")
-  rmarkdown::render("README.Rmd")
-  generated_readme <- read.file("README.md")
+  current_readme <- readLines("../../../README.md")
+  rmarkdown::render("../../../README.Rmd")
+  generated_readme <- readLines("../../../README.md")
   expect_equal(current_readme, generated_readme)
 })

--- a/rpackage/tests/testthat/test-readme.R
+++ b/rpackage/tests/testthat/test-readme.R
@@ -1,0 +1,9 @@
+
+context("test-readme")
+
+test_that("Check that the generated README is up-to-date", {
+  current_readme <- read.file("README.md")
+  rmarkdown::render("README.Rmd")
+  generated_readme <- read.file("README.md")
+  expect_equal(current_readme, generated_readme)
+})


### PR DESCRIPTION
Fixes #65 

This test sort of works right now, but not completely yet.

- The generation settings on travis seem to be slightly different from what was used to generate the current README (see later comments in this thread)
- The code outputs contain absolute paths like
  ```R
  dfp <- data_file_path(po)
  dfp
  ## [1] "/var/folders/9h/yf354vb917z6gr6mz7bfb1d40000gn/T//RtmptE97ZB/posteriordb_cache/data/data/eight_schools.json"
  ```
  These paths will be different when running on CI, causing the test to fail
- The test might not work on Windows as it uses unix-style paths