### PR TITLE
Add pymc3 eight schools model

### DIFF
--- a/posterior_database/models/info/eight_schools_noncentered.info.json
+++ b/posterior_database/models/info/eight_schools_noncentered.info.json
@@ -13,7 +13,8 @@
     "gelman2013bayesian"
   ],
   "model_code": {
-    "stan": "models/stan/eight_schools_noncentered.stan"
+    "stan": "models/stan/eight_schools_noncentered.stan",
+    "pymc3": "models/pymc3/eight_schools_noncentered.py"
   },
   "added_by": "Mans Magnusson",
   "added_date": "2019-08-12"

--- a/posterior_database/models/pymc3/eight_schools_noncentered.py
+++ b/posterior_database/models/pymc3/eight_schools_noncentered.py
@@ -1,0 +1,17 @@
+import pymc3 as pm3
+
+
+def model(data):
+    J = data["J"]  # number of schools
+    y_obs = data["y"]  # estimated treatment
+    sigma = data["sigma"]  # std of estimated effect
+    with pm3.Model() as pymc_model:
+
+        mu = pm3.Normal(
+            "mu", mu=0, sd=5
+        )  # hyper-parameter of mean, non-informative prior
+        tau = pm3.Cauchy("tau", alpha=0, beta=5)  # hyper-parameter of sd
+        theta_trans = pm3.Normal("theta_trans", mu=0, sd=1, shape=J)
+        theta = mu + tau * theta_trans
+        y = pm3.Normal("y", mu=theta, sd=sigma, observed=y_obs)
+    return pymc_model


### PR DESCRIPTION
I added the model under the namespace `pymc3` as `pymc4` is coming at some point with a different API. Related to #117 