### PR TITLE
Add model implementations API for python

### DIFF
--- a/python/src/posteriordb/model_implementation_base.py
+++ b/python/src/posteriordb/model_implementation_base.py
@@ -1,0 +1,8 @@
+from abc import ABC
+from abc import abstractmethod
+
+
+class ModelImplementationBase(ABC):
+    @abstractmethod
+    def load(self):
+        pass

--- a/python/src/posteriordb/posterior_database.py
+++ b/python/src/posteriordb/posterior_database.py
@@ -36,6 +36,9 @@ class PosteriorDatabase:
         self.path = path
         # TODO assert that path is a valid posterior database
 
+    def full_path(self, path: str):
+        return os.path.join(self.path, path)
+
     def posterior(self, name):
         # inline import needed to avoid import loop
         from .posterior import Posterior

--- a/python/src/posteriordb/posterior_database.py
+++ b/python/src/posteriordb/posterior_database.py
@@ -77,7 +77,9 @@ class PosteriorDatabase:
 
     def get_model_code_path(self, name, framework):
         model_info = self.get_model_info(name)
-        path_within_posterior_db = model_info["model_code"][framework]
+        path_within_posterior_db = model_info["model_implementations"][framework][
+            "model_code"
+        ]
         full_path = os.path.join(self.path, path_within_posterior_db)
         return full_path
 

--- a/python/src/posteriordb/pymc3_model_implementation.py
+++ b/python/src/posteriordb/pymc3_model_implementation.py
@@ -1,0 +1,39 @@
+import os
+import sys
+
+from .model_implementation_base import ModelImplementationBase
+
+
+class add_path:
+    def __init__(self, path):
+        self.path = path
+
+    def __enter__(self):
+        sys.path.insert(0, self.path)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        try:
+            sys.path.remove(self.path)
+        except ValueError:
+            pass
+
+
+class PyMC3ModelImplementation(ModelImplementationBase):
+    def __init__(self, posterior_db, *, model_code):
+        self.posterior_db = posterior_db
+        self.model_code = model_code
+
+    def load(self):
+        try:
+            import pymc3
+        except ImportError:
+            raise ValueError("pymc3 needs to be installed")
+        import importlib
+
+        model_code_file = self.posterior_db.full_path(self.model_code)
+        model_code_directory = os.path.dirname(model_code_file)
+        with add_path(model_code_directory):
+            model_code_module_name = os.path.basename(model_code_file).strip(".py")
+            module = importlib.import_module(model_code_module_name)
+
+        return module.model

--- a/python/src/posteriordb/stan_model_implementation.py
+++ b/python/src/posteriordb/stan_model_implementation.py
@@ -1,0 +1,16 @@
+from .model_implementation_base import ModelImplementationBase
+
+
+class StanModelImplementation(ModelImplementationBase):
+    def __init__(self, posterior_db, *, model_code):
+        self.posterior_db = posterior_db
+        self.model_code = model_code
+
+    def load(self):
+        try:
+            import pystan
+        except ImportError:
+            raise ValueError("`pystan` needs to be installed")
+        model_code_file = self.posterior_db.full_path(self.model_code)
+        stan_model = pystan.StanModel(file=model_code_file)
+        return stan_model


### PR DESCRIPTION
This depends on #127 and should not be merged before it

This PR is mostly to make the discussion in #125 more concrete. If we reach the conclusion that this functionality should not be added then that's how it will be. However at least currently I think that this would be a good addition. 

Add method `implementations` to `Model`, which takes a framework name and returns
a model implementation object for that framework.

Currently model implementation objects only have a `load` method. Calling it loads
the underlying model of the framework being used.

Here's an example how this might be used. (running these needs PR #129) 
```python
from posteriordb import PosteriorDatabase
my_pdb = PosteriorDatabase("../posterior_database/") # replace path if needed
model = my_pdb.model("eight_schools_centered")
data = my_pdb.data("eight_schools")
```

We can load a Stan model and obtain posterior draws

```python
stan_imp = model.implementation("stan")
stan_model = stan_imp.load()
stan_draws = stan_model.sampling(data=data.values())
```

We can do the same with a PyMC3 model

```python
import pymc3
pymc_imp = model.implementation("pymc3")
get_pymc_model = pymc_imp.load()
pymc_model = get_pymc_model(data.values())
pymc_draws = pymc3.sampling.sample(model=pymc_model)
```

Further down the line we might want to also add other methods to the model
implementation objects. Obtaining prior or predictive draws might be one of
these potential new methods.