### PR TITLE
Fix pymc3 model for `eight_schools_centered`

### DIFF
--- a/posterior_database/models/info/eight_schools_centered.info.json
+++ b/posterior_database/models/info/eight_schools_centered.info.json
@@ -19,6 +19,9 @@
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/eight_schools_centered.stan"
+    },
+    "pymc3": {
+      "model_code": "models/pymc3/eight_schools_noncentered.py"
     }
   },
   "added_by": "Mans Magnusson",

--- a/posterior_database/models/pymc3/eight_schools_noncentered.py
+++ b/posterior_database/models/pymc3/eight_schools_noncentered.py
@@ -1,10 +1,11 @@
+import numpy as np
 import pymc3 as pm3
 
 
 def model(data):
     J = data["J"]  # number of schools
-    y_obs = data["y"]  # estimated treatment
-    sigma = data["sigma"]  # std of estimated effect
+    y_obs = np.array(data["y"])  # estimated treatment
+    sigma = np.array(data["sigma"])  # std of estimated effect
     with pm3.Model() as pymc_model:
 
         mu = pm3.Normal(


### PR DESCRIPTION
Commit 426376177fbb518510ae09815eb8a8879473826a accidently removed the pymc3 model code from the `eight_schools_centered`
model, this adds it back.
The model code also needed a few changes to actually work with PyMC. Those changes are
included here.