### PR TITLE
Add posterior.information to python API

### DIFF
--- a/python/src/posteriordb/posterior.py
+++ b/python/src/posteriordb/posterior.py
@@ -1,6 +1,7 @@
 from .dataset import Dataset
 from .model import Model
 from .posterior_database import PosteriorDatabase
+from .util import drop_keys
 
 
 class Posterior:
@@ -14,6 +15,11 @@ class Posterior:
         self.model = Model(self.posterior_info["model_name"], posterior_db)
 
         self.data = Dataset(self.posterior_info["data_name"], posterior_db)
+
+        self.information = drop_keys(
+            self.posterior_info,
+            ["name", "model_name", "data_name", "reference_posterior_name"],
+        )
 
     def gold_standard(self):
         # gold_standard_file = self.posterior_info["gold_standard"]


### PR DESCRIPTION
The python API has `model.information` and `data.information` for accessing information about models and datasets. This PR adds `posterior.information` for accessing information about posteriors.

For example with posterior `eight_schools-eight_schools_noncentered` calling `posterior.information["keywords"]` will return `["stan_benchmark"]` (or whatever https://github.com/MansMeg/posteriordb/blob/master/posterior_database/posteriors/eight_schools.json contains at the time of calling the code)