### PR TITLE
Add information about the inputs of the models

### DIFF
--- a/posterior_database/models/info/accel_gp.info.json
+++ b/posterior_database/models/info/accel_gp.info.json
@@ -7,6 +7,19 @@
   },
   "description": "accel ~ gp(times, k=40, c=3/2,\nsigma ~ gp(times, k=20, c=3/2)",
   "urls": "https://github.com/bbbales2/cmdstan-warmup/blob/develop/examples/accel_gp/",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "Y": { "type": "real", "dimensions": 1},
+              "Kgp_1": { "type": "int", "dimensions": 0},
+              "Dgp_1": { "type": "int", "dimensions": 0},
+              "NBgp_1": { "type": "int", "dimensions": 0},
+              "Xgp_1": { "type": "real", "dimensions": 2},
+              "slambda_1": { "type": "real", "dimensions": 2},
+              "Kgp_sigma_1": { "type": "int", "dimensions": 0},
+              "Dgp_sigma_1": { "type": "int", "dimensions": 0},
+              "NBgp_sigma_1": { "type": "int", "dimensions": 0},
+              "Xgp_sigma_1": { "type": "real", "dimensions": 2},
+              "slambda_sigma_1": { "type": "real", "dimensions": 2},
+              "prior_only": { "type": "int", "dimensions": 0} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/accel_gp.stan"

--- a/posterior_database/models/info/accel_splines.info.json
+++ b/posterior_database/models/info/accel_splines.info.json
@@ -7,6 +7,17 @@
   },
   "description": "accel ~ s(times, k=40),\nsigma ~ s(times, k=40)",
   "urls": "https://github.com/bbbales2/cmdstan-warmup/blob/develop/examples/accel_splines/",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "Y": { "type": "real", "dimensions": 1},
+              "Ks": { "type": "int", "dimensions": 0},
+              "Xs": { "type": "real", "dimensions": 2},
+              "knots_1": { "type": "int", "dimensions": 0},
+              "Zs_1_1": { "type": "real", "dimensions": 2},
+              "Ks_sigma": { "type": "int", "dimensions": 0},
+              "Xs_sigma": { "type": "real", "dimensions": 2},
+              "knots_sigma_1": { "type": "int", "dimensions": 0},
+              "Zs_sigma_1_1": { "type": "real", "dimensions": 2},
+              "prior_only": { "type": "int", "dimensions": 0} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/accel_splines.stan"

--- a/posterior_database/models/info/arK.info.json
+++ b/posterior_database/models/info/arK.info.json
@@ -12,6 +12,9 @@
   "prior": {
     "keywords": []
   },
+  "inputs": { "K": { "type": "int", "dimensions": 0},
+              "T": { "type": "int", "dimensions": 0},
+              "y": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/arK.stan"

--- a/posterior_database/models/info/arma11.info.json
+++ b/posterior_database/models/info/arma11.info.json
@@ -12,6 +12,8 @@
   "prior": {
     "keywords": []
   },
+  "inputs": { "T": { "type": "int", "dimensions": 0},
+              "y": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/arma11.stan"

--- a/posterior_database/models/info/blr.info.json
+++ b/posterior_database/models/info/blr.info.json
@@ -8,6 +8,10 @@
   "prior": {
     "keywords": []
   },
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "D": { "type": "int", "dimensions": 0},
+              "X": { "type": "real", "dimensions": 2},
+              "y": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/blr.stan"

--- a/posterior_database/models/info/covid19imperial_v2.info.json
+++ b/posterior_database/models/info/covid19imperial_v2.info.json
@@ -7,6 +7,18 @@
   },
   "description": "A Bayesian model for estimating intervetion effects in the 2020 covid-19 pandemic.",
   "urls": "https://github.com/ImperialCollegeLondon/covid19model",
+  "inputs": { "M": { "type": "int", "dimensions": 0},
+              "P": { "type": "int", "dimensions": 0},
+              "N0": { "type": "int", "dimensions": 0},
+              "N": { "type": "int", "dimensions": 1},
+              "N2": { "type": "int", "dimensions": 0},
+              "cases": { "type": "int", "dimensions": 2},
+              "deaths": { "type": "int", "dimensions": 2},
+              "f": { "type": "real", "dimensions": 2},
+              "X": { "type": "real", "dimensions": 3},
+              "EpidemicStart": { "type": "int", "dimensions": 1},
+              "pop": { "type": "real", "dimensions": 1},
+              "SI": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/covid19imperial_v2.stan"

--- a/posterior_database/models/info/covid19imperial_v3.info.json
+++ b/posterior_database/models/info/covid19imperial_v3.info.json
@@ -7,6 +7,18 @@
   },
   "description": "A Bayesian model for estimating intervetion effects in the 2020 covid-19 pandemic.",
   "urls": "https://github.com/ImperialCollegeLondon/covid19model",
+  "inputs": { "M": { "type": "int", "dimensions": 0},
+              "P": { "type": "int", "dimensions": 0},
+              "N0": { "type": "int", "dimensions": 0},
+              "N": { "type": "int", "dimensions": 1},
+              "N2": { "type": "int", "dimensions": 0},
+              "cases": { "type": "int", "dimensions": 2},
+              "deaths": { "type": "int", "dimensions": 2},
+              "f": { "type": "real", "dimensions": 2},
+              "X": { "type": "real", "dimensions": 3},
+              "EpidemicStart": { "type": "int", "dimensions": 1},
+              "pop": { "type": "real", "dimensions": 1},
+              "SI": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/covid19imperial_v3.stan"

--- a/posterior_database/models/info/diamonds.info.json
+++ b/posterior_database/models/info/diamonds.info.json
@@ -7,6 +7,11 @@
   },
   "description": "log(price) ~ carat * (log(x) + log(y) + log(z)) + cut + color + clarity",
   "urls": "https://github.com/bbbales2/cmdstan-warmup/blob/develop/examples/diamonds",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "Y": { "type": "real", "dimensions": 1},
+              "K": { "type": "int", "dimensions": 0},
+              "X": { "type": "real", "dimensions": 2},
+              "prior_only": { "type": "int", "dimensions": 0} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/diamonds.stan"

--- a/posterior_database/models/info/dogs.info.json
+++ b/posterior_database/models/info/dogs.info.json
@@ -7,6 +7,9 @@
   },
   "description": "y ~ logistic(n_avoid + n_shock)",
   "urls": "https://raw.githubusercontent.com/stan-dev/example-models/master/ARM/Ch.24/dogs.stan",
+  "inputs": { "n_dogs": { "type": "int", "dimensions": 0},
+              "n_trials": { "type": "int", "dimensions": 0},
+              "y": { "type": "int", "dimensions": 2} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/dogs.stan"

--- a/posterior_database/models/info/dogs_log.info.json
+++ b/posterior_database/models/info/dogs_log.info.json
@@ -7,6 +7,9 @@
   },
   "description": "y ~ exp(n_avoid + n_shock)",
   "urls": "https://raw.githubusercontent.com/stan-dev/example-models/master/ARM/Ch.24/dogs_log.stan",
+  "inputs": { "n_trials": { "type": "int", "dimensions": 0},
+              "n_dogs": { "type": "int", "dimensions": 0},
+              "y": { "type": "int", "dimensions": 2} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/dogs_log.stan"

--- a/posterior_database/models/info/earn_height.info.json
+++ b/posterior_database/models/info/earn_height.info.json
@@ -7,6 +7,9 @@
   },
   "description": "earn ~ height",
   "urls": "https://raw.githubusercontent.com/stan-dev/example-models/master/ARM/Ch.4/earn_height.stan",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "earn": { "type": "real", "dimensions": 1},
+              "height": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/earn_height.stan"

--- a/posterior_database/models/info/eight_schools_centered.info.json
+++ b/posterior_database/models/info/eight_schools_centered.info.json
@@ -16,6 +16,9 @@
   "prior": {
     "keywords": []
   },
+  "inputs": { "J": { "type": "int", "dimensions": 0},
+              "y": { "type": "real", "dimensions": 1},
+              "sigma": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/eight_schools_centered.stan"

--- a/posterior_database/models/info/eight_schools_noncentered.info.json
+++ b/posterior_database/models/info/eight_schools_noncentered.info.json
@@ -15,6 +15,9 @@
   "prior": {
     "keywords": []
   },
+  "inputs": { "J": { "type": "int", "dimensions": 0},
+              "y": { "type": "real", "dimensions": 1},
+              "sigma": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/eight_schools_noncentered.stan"

--- a/posterior_database/models/info/election88_full.info.json
+++ b/posterior_database/models/info/election88_full.info.json
@@ -7,6 +7,21 @@
   },
   "description": "y ~ logistic(black + female + v_prev_full + (1 | age) + (1 | age_edu) \n+ (1 | state) + (1 | region_full))",
   "urls": "https://raw.githubusercontent.com/stan-dev/example-models/master/ARM/Ch.14/election88_full.stan",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "n_age": { "type": "int", "dimensions": 0},
+              "n_age_edu": { "type": "int", "dimensions": 0},
+              "n_edu": { "type": "int", "dimensions": 0},
+              "n_region_full": { "type": "int", "dimensions": 0},
+              "n_state": { "type": "int", "dimensions": 0},
+              "age": { "type": "int", "dimensions": 1},
+              "age_edu": { "type": "int", "dimensions": 1},
+              "black": { "type": "real", "dimensions": 1},
+              "edu": { "type": "int", "dimensions": 1},
+              "female": { "type": "real", "dimensions": 1},
+              "region_full": { "type": "int", "dimensions": 1},
+              "state": { "type": "int", "dimensions": 1},
+              "v_prev_full": { "type": "real", "dimensions": 1},
+              "y": { "type": "int", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/election88_full.stan"

--- a/posterior_database/models/info/garch11.info.json
+++ b/posterior_database/models/info/garch11.info.json
@@ -13,6 +13,9 @@
   "prior": {
     "keywords": []
   },
+  "inputs": { "T": { "type": "int", "dimensions": 0},
+              "y": { "type": "real", "dimensions": 1},
+              "sigma1": { "type": "real", "dimensions": 0} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/garch11.stan"

--- a/posterior_database/models/info/gp_pois_regr.info.json
+++ b/posterior_database/models/info/gp_pois_regr.info.json
@@ -13,6 +13,9 @@
   "prior": {
     "keywords": []
   },
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "x": { "type": "real", "dimensions": 1},
+              "k": { "type": "int", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/gp_pois_regr.stan"

--- a/posterior_database/models/info/gp_regr.info.json
+++ b/posterior_database/models/info/gp_regr.info.json
@@ -13,6 +13,9 @@
   "prior": {
     "keywords": []
   },
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "x": { "type": "real", "dimensions": 1},
+              "y": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/gp_regr.stan"

--- a/posterior_database/models/info/hier_2pl.info.json
+++ b/posterior_database/models/info/hier_2pl.info.json
@@ -7,6 +7,12 @@
   },
   "description": "Hierachical item response theory model that includes\nparameters for both the difficulty and discrimination of items.\nItem parameter pairs are modeled as correlated draws from a bivariate normal distribution",
   "urls": "https://mc-stan.org/users/documentation/case-studies/hierarchical_2pl.html",
+  "inputs": { "I": { "type": "int", "dimensions": 0},
+              "J": { "type": "int", "dimensions": 0},
+              "N": { "type": "int", "dimensions": 0},
+              "ii": { "type": "int", "dimensions": 1},
+              "jj": { "type": "int", "dimensions": 1},
+              "y": { "type": "int", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/hier_2pl.stan"

--- a/posterior_database/models/info/hmm_drive_0.info.json
+++ b/posterior_database/models/info/hmm_drive_0.info.json
@@ -7,6 +7,11 @@
   },
   "description": "A Hidden Markov Model with exponential distribution for emission probabilities",
   "urls": "https://github.com/imadmali/bball-hmm/blob/master/models/drive_0.stan",
+  "inputs": { "K": { "type": "int", "dimensions": 0},
+              "N": { "type": "int", "dimensions": 0},
+              "u": { "type": "real", "dimensions": 1},
+              "v": { "type": "real", "dimensions": 1},
+              "alpha": { "type": "real", "dimensions": 2} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/hmm_drive_0.stan"

--- a/posterior_database/models/info/hmm_drive_1.info.json
+++ b/posterior_database/models/info/hmm_drive_1.info.json
@@ -7,6 +7,13 @@
   },
   "description": "A Hidden Markov Model with normal distribution for emission probabilities",
   "urls": "https://github.com/imadmali/bball-hmm/blob/master/models/drive_1.stan",
+  "inputs": { "K": { "type": "int", "dimensions": 0},
+              "N": { "type": "int", "dimensions": 0},
+              "u": { "type": "real", "dimensions": 1},
+              "v": { "type": "real", "dimensions": 1},
+              "alpha": { "type": "real", "dimensions": 2},
+              "tau": { "type": "real", "dimensions": 0},
+              "rho": { "type": "real", "dimensions": 0} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/hmm_drive_1.stan"

--- a/posterior_database/models/info/hmm_example.info.json
+++ b/posterior_database/models/info/hmm_example.info.json
@@ -7,6 +7,9 @@
   },
   "description": "A Hidden Markov Model",
   "urls": "https://github.com/imadmali/bball-hmm/blob/master/models/hmm_example.stan",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "K": { "type": "int", "dimensions": 0},
+              "y": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/hmm_example.stan"

--- a/posterior_database/models/info/irt_2pl.info.json
+++ b/posterior_database/models/info/irt_2pl.info.json
@@ -13,6 +13,9 @@
   "prior": {
     "keywords": []
   },
+  "inputs": { "I": { "type": "int", "dimensions": 0},
+              "J": { "type": "int", "dimensions": 0},
+              "y": { "type": "int", "dimensions": 2} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/irt_2pl.stan"

--- a/posterior_database/models/info/kidscore_interaction.info.json
+++ b/posterior_database/models/info/kidscore_interaction.info.json
@@ -7,6 +7,10 @@
   },
   "description": "kid_score ~ mom_hs + mom_iq + mom_hs:mom_iq",
   "urls": "https://raw.githubusercontent.com/stan-dev/example-models/master/ARM/Ch.3/kidiq_interaction.stan",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "kid_score": { "type": "real", "dimensions": 1},
+              "mom_iq": { "type": "real", "dimensions": 1},
+              "mom_hs": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/kidscore_interaction.stan"

--- a/posterior_database/models/info/kidscore_interaction_c.info.json
+++ b/posterior_database/models/info/kidscore_interaction_c.info.json
@@ -7,6 +7,10 @@
   },
   "description": "kid_score ~ c_mom_hs + c_mom_iq + c_mom_hs:c_mom_iq",
   "urls": "https://raw.githubusercontent.com/stan-dev/example-models/master/ARM/Ch.4/kidiq_interaction_c.stan",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "kid_score": { "type": "real", "dimensions": 1},
+              "mom_hs": { "type": "real", "dimensions": 1},
+              "mom_iq": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/kidscore_interaction_c.stan"

--- a/posterior_database/models/info/kidscore_interaction_c2.info.json
+++ b/posterior_database/models/info/kidscore_interaction_c2.info.json
@@ -7,6 +7,10 @@
   },
   "description": "kid_score ~ c2_mom_hs + c2_mom_iq + c2_mom_hs:c2_mom_iq, c2_mom_hs <- mom_hs - 0.5, c2_mom_iq <- mom_iq - 100",
   "urls": "https://raw.githubusercontent.com/stan-dev/example-models/master/ARM/Ch.4/kidiq_interaction_c2.stan",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "kid_score": { "type": "real", "dimensions": 1},
+              "mom_hs": { "type": "real", "dimensions": 1},
+              "mom_iq": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/kidscore_interaction_c2.stan"

--- a/posterior_database/models/info/kidscore_interaction_z.info.json
+++ b/posterior_database/models/info/kidscore_interaction_z.info.json
@@ -7,6 +7,10 @@
   },
   "description": "kid_score ~ z_mom_hs + z_mom_iq + z_mom_hs:z_mom_iq",
   "urls": "https://raw.githubusercontent.com/stan-dev/example-models/master/ARM/Ch.4/kidiq_interaction_z.stan",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "kid_score": { "type": "real", "dimensions": 1},
+              "mom_hs": { "type": "real", "dimensions": 1},
+              "mom_iq": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/kidscore_interaction_z.stan"

--- a/posterior_database/models/info/kidscore_mom_work.info.json
+++ b/posterior_database/models/info/kidscore_mom_work.info.json
@@ -7,6 +7,9 @@
   },
   "description": "kid_score ~ as.factor(mom_work)",
   "urls": "https://raw.githubusercontent.com/stan-dev/example-models/master/ARM/Ch.4/kidscore_momwork.stan",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "kid_score": { "type": "real", "dimensions": 1},
+              "mom_work": { "type": "int", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/kidscore_mom_work.stan"

--- a/posterior_database/models/info/kidscore_momhs.info.json
+++ b/posterior_database/models/info/kidscore_momhs.info.json
@@ -7,6 +7,9 @@
   },
   "description": "kid_score ~ mom_hs",
   "urls": "https://raw.githubusercontent.com/stan-dev/example-models/master/ARM/Ch.3/kidscore_momhs.stan",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "kid_score": { "type": "real", "dimensions": 1},
+              "mom_hs": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/kidscore_momhs.stan"

--- a/posterior_database/models/info/kidscore_momhsiq.info.json
+++ b/posterior_database/models/info/kidscore_momhsiq.info.json
@@ -7,6 +7,10 @@
   },
   "description": "kid_score ~ mom_hs + mom_iq",
   "urls": "https://raw.githubusercontent.com/stan-dev/example-models/master/ARM/Ch.3/kidiq_multi_preds.stan",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "kid_score": { "type": "real", "dimensions": 1},
+              "mom_iq": { "type": "real", "dimensions": 1},
+              "mom_hs": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/kidscore_momhsiq.stan"

--- a/posterior_database/models/info/kidscore_momiq.info.json
+++ b/posterior_database/models/info/kidscore_momiq.info.json
@@ -7,6 +7,9 @@
   },
   "description": "kid_score ~ mom_iq",
   "urls": "https://raw.githubusercontent.com/stan-dev/example-models/master/ARM/Ch.3/kidscore_momiq.stan",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "kid_score": { "type": "real", "dimensions": 1},
+              "mom_iq": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/kidscore_momiq.stan"

--- a/posterior_database/models/info/kilpisjarvi.info.json
+++ b/posterior_database/models/info/kilpisjarvi.info.json
@@ -7,6 +7,14 @@
   },
   "description": "y ~ x",
   "urls": "https://raw.githubusercontent.com/bbbales2/cmdstan-warmup/develop/examples/kilpisjarvi/kilpisjarvi.stan",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "x": { "type": "real", "dimensions": 1},
+              "y": { "type": "real", "dimensions": 1},
+              "xpred": { "type": "real", "dimensions": 0},
+              "pmualpha": { "type": "real", "dimensions": 0},
+              "psalpha": { "type": "real", "dimensions": 0},
+              "pmubeta": { "type": "real", "dimensions": 0},
+              "psbeta": { "type": "real", "dimensions": 0} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/kilpisjarvi.stan"

--- a/posterior_database/models/info/ldaK5.info.json
+++ b/posterior_database/models/info/ldaK5.info.json
@@ -12,6 +12,13 @@
   "prior": {
     "keywords": []
   },
+  "inputs": { "V": { "type": "int", "dimensions": 0},
+              "M": { "type": "int", "dimensions": 0},
+              "N": { "type": "int", "dimensions": 0},
+              "w": { "type": "int", "dimensions": 1},
+              "doc": { "type": "int", "dimensions": 1},
+              "alpha": { "type": "real", "dimensions": 1},
+              "beta": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/ldaK5.stan"

--- a/posterior_database/models/info/log10earn_height.info.json
+++ b/posterior_database/models/info/log10earn_height.info.json
@@ -7,6 +7,9 @@
   },
   "description": "log10(earn) ~ height",
   "urls": "https://raw.githubusercontent.com/stan-dev/example-models/master/ARM/Ch.4/log10earn_height.stan",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "earn": { "type": "real", "dimensions": 1},
+              "height": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/log10earn_height.stan"

--- a/posterior_database/models/info/logearn_height.info.json
+++ b/posterior_database/models/info/logearn_height.info.json
@@ -7,6 +7,9 @@
   },
   "description": "log(earn) ~ height",
   "urls": "https://raw.githubusercontent.com/stan-dev/example-models/master/ARM/Ch.4/logearn_height.stan",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "earn": { "type": "real", "dimensions": 1},
+              "height": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/logearn_height.stan"

--- a/posterior_database/models/info/logearn_height_male.info.json
+++ b/posterior_database/models/info/logearn_height_male.info.json
@@ -7,6 +7,10 @@
   },
   "description": "log(earn) ~ height + male",
   "urls": "https://raw.githubusercontent.com/stan-dev/example-models/master/ARM/Ch.4/logearn_height_male.stan",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "earn": { "type": "real", "dimensions": 1},
+              "height": { "type": "real", "dimensions": 1},
+              "male": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/logearn_height_male.stan"

--- a/posterior_database/models/info/logearn_interaction.info.json
+++ b/posterior_database/models/info/logearn_interaction.info.json
@@ -7,6 +7,10 @@
   },
   "description": "log(earn) ~ height + male + height:male",
   "urls": "https://raw.githubusercontent.com/stan-dev/example-models/master/ARM/Ch.4/logearn_interaction.stan",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "earn": { "type": "real", "dimensions": 1},
+              "height": { "type": "real", "dimensions": 1},
+              "male": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/logearn_interaction.stan"

--- a/posterior_database/models/info/logearn_interaction_z.info.json
+++ b/posterior_database/models/info/logearn_interaction_z.info.json
@@ -7,6 +7,10 @@
   },
   "description": "log(earn) ~ z_height + male + z_height:male",
   "urls": "https://raw.githubusercontent.com/stan-dev/example-models/master/ARM/Ch.4/logearn_interaction_z.stan",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "earn": { "type": "real", "dimensions": 1},
+              "height": { "type": "real", "dimensions": 1},
+              "male": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/logearn_interaction_z.stan"

--- a/posterior_database/models/info/logearn_logheight_male.info.json
+++ b/posterior_database/models/info/logearn_logheight_male.info.json
@@ -7,6 +7,10 @@
   },
   "description": "log(earn) ~ log(height) + male",
   "urls": "https://raw.githubusercontent.com/stan-dev/example-models/master/ARM/Ch.4/logearn_logheight.stan",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "earn": { "type": "real", "dimensions": 1},
+              "height": { "type": "real", "dimensions": 1},
+              "male": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/logearn_logheight_male.stan"

--- a/posterior_database/models/info/logistic_regression_rhs.info.json
+++ b/posterior_database/models/info/logistic_regression_rhs.info.json
@@ -7,6 +7,16 @@
   },
   "description": "y ~ Ber(x)",
   "urls": "",
+  "inputs": { "n": { "type": "int", "dimensions": 0},
+              "d": { "type": "int", "dimensions": 0},
+              "y": { "type": "int", "dimensions": 1},
+              "x": { "type": "real", "dimensions": 2},
+              "scale_icept": { "type": "real", "dimensions": 0},
+              "scale_global": { "type": "real", "dimensions": 0},
+              "nu_global": { "type": "real", "dimensions": 0},
+              "nu_local": { "type": "real", "dimensions": 0},
+              "slab_scale": { "type": "real", "dimensions": 0},
+              "slab_df": { "type": "real", "dimensions": 0} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/logistic_regression_rhs.stan"

--- a/posterior_database/models/info/logmesquite.info.json
+++ b/posterior_database/models/info/logmesquite.info.json
@@ -7,6 +7,14 @@
   },
   "description": "log(weight) ~ log(diam1) + log(diam2) + log(canopy.height) + log(total.height) + log(density) + group",
   "urls": "https://raw.githubusercontent.com/stan-dev/example-models/master/ARM/Ch.4/mesquite_log.stan",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "weight": { "type": "real", "dimensions": 1},
+              "diam1": { "type": "real", "dimensions": 1},
+              "diam2": { "type": "real", "dimensions": 1},
+              "canopy_height": { "type": "real", "dimensions": 1},
+              "total_height": { "type": "real", "dimensions": 1},
+              "density": { "type": "real", "dimensions": 1},
+              "group": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/logmesquite.stan"

--- a/posterior_database/models/info/logmesquite_logva.info.json
+++ b/posterior_database/models/info/logmesquite_logva.info.json
@@ -7,6 +7,12 @@
   },
   "description": "log(weight) ~ log(canopy.volume) + log(canopy.area) + group\ncanopy_volume <- diam1 * diam2 * canopy_height\ncanopy_area   <- diam1 * diam2",
   "urls": "https://raw.githubusercontent.com/stan-dev/example-models/master/ARM/Ch.4/mesquite_va.stan",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "weight": { "type": "real", "dimensions": 1},
+              "diam1": { "type": "real", "dimensions": 1},
+              "diam2": { "type": "real", "dimensions": 1},
+              "canopy_height": { "type": "real", "dimensions": 1},
+              "group": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/logmesquite_logva.stan"

--- a/posterior_database/models/info/logmesquite_logvas.info.json
+++ b/posterior_database/models/info/logmesquite_logvas.info.json
@@ -7,6 +7,14 @@
   },
   "description": "log(weight) ~ log(canopy.volume) + log(canopy.area) + log(canopy.shape) + log(total.height) + log(density) + group\ncanopy_volume <- diam1 * diam2 * canopy_height\ncanopy_area   <- diam1 * diam2\ncanopy_shape  <- diam1 / diam2",
   "urls": "https://raw.githubusercontent.com/stan-dev/example-models/master/ARM/Ch.4/mesquite_vas.stan",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "weight": { "type": "real", "dimensions": 1},
+              "diam1": { "type": "real", "dimensions": 1},
+              "diam2": { "type": "real", "dimensions": 1},
+              "canopy_height": { "type": "real", "dimensions": 1},
+              "total_height": { "type": "real", "dimensions": 1},
+              "density": { "type": "real", "dimensions": 1},
+              "group": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/logmesquite_logvas.stan"

--- a/posterior_database/models/info/logmesquite_logvash.info.json
+++ b/posterior_database/models/info/logmesquite_logvash.info.json
@@ -7,6 +7,13 @@
   },
   "description": "log(weight) ~ log(canopy.volume) + log(canopy.area) + log(canopy.shape) + log(total.height) + group\ncanopy_volume <- diam1 * diam2 * canopy_height\ncanopy_area   <- diam1 * diam2\ncanopy_shape  <- diam1 / diam2",
   "urls": "https://raw.githubusercontent.com/stan-dev/example-models/master/ARM/Ch.4/mesquite_vash.stan",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "weight": { "type": "real", "dimensions": 1},
+              "diam1": { "type": "real", "dimensions": 1},
+              "diam2": { "type": "real", "dimensions": 1},
+              "canopy_height": { "type": "real", "dimensions": 1},
+              "total_height": { "type": "real", "dimensions": 1},
+              "group": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/logmesquite_logvash.stan"

--- a/posterior_database/models/info/logmesquite_logvolume.info.json
+++ b/posterior_database/models/info/logmesquite_logvolume.info.json
@@ -7,6 +7,11 @@
   },
   "description": "log(weight) ~ log(canopy_volume)\ncanopy_volume <- diam1 * diam2 * canopy_height",
   "urls": "https://raw.githubusercontent.com/stan-dev/example-models/master/ARM/Ch.4/mesquite_volume.stan",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "weight": { "type": "real", "dimensions": 1},
+              "diam1": { "type": "real", "dimensions": 1},
+              "diam2": { "type": "real", "dimensions": 1},
+              "canopy_height": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/logmesquite_logvolume.stan"

--- a/posterior_database/models/info/lotka_volterra.info.json
+++ b/posterior_database/models/info/lotka_volterra.info.json
@@ -7,6 +7,10 @@
   },
   "description": "A statistical model to account for measurement error and unexplained variation\nthat uses the deterministic solutions to the Lotka-Volterra equations as expected population sizes",
   "urls": "https://raw.githubusercontent.com/stan-dev/example-models/master/knitr/lotka-volterra/lotka-volterra.stan",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "ts": { "type": "real", "dimensions": 1},
+              "y_init": { "type": "real", "dimensions": 1},
+              "y": { "type": "real", "dimensions": 2} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/lotka_volterra.stan"

--- a/posterior_database/models/info/low_dim_gauss_mix.info.json
+++ b/posterior_database/models/info/low_dim_gauss_mix.info.json
@@ -13,6 +13,8 @@
   "prior": {
     "keywords": []
   },
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "y": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/low_dim_gauss_mix.stan"

--- a/posterior_database/models/info/low_dim_gauss_mix_collapse.info.json
+++ b/posterior_database/models/info/low_dim_gauss_mix_collapse.info.json
@@ -13,6 +13,8 @@
   "prior": {
     "keywords": []
   },
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "y": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/low_dim_gauss_mix_collapse.stan"

--- a/posterior_database/models/info/mesquite.info.json
+++ b/posterior_database/models/info/mesquite.info.json
@@ -7,6 +7,14 @@
   },
   "description": "weight ~ diam1 + diam2 + canopy.height + total.height + density + group",
   "urls": "https://raw.githubusercontent.com/stan-dev/example-models/master/ARM/Ch.4/mesquite.stan",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "weight": { "type": "real", "dimensions": 1},
+              "diam1": { "type": "real", "dimensions": 1},
+              "diam2": { "type": "real", "dimensions": 1},
+              "canopy_height": { "type": "real", "dimensions": 1},
+              "total_height": { "type": "real", "dimensions": 1},
+              "density": { "type": "real", "dimensions": 1},
+              "group": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/mesquite.stan"

--- a/posterior_database/models/info/multi_occupancy.info.json
+++ b/posterior_database/models/info/multi_occupancy.info.json
@@ -7,6 +7,11 @@
   },
   "description": "a hierarchical occupancy model for estimating\nspecies richness and accumulation by forming these community-level\nattributes as functions of model-based estimators of species occurence\nwhile accounting for imperfect detection of individual species.",
   "urls": "",
+  "inputs": { "J": { "type": "int", "dimensions": 0},
+              "K": { "type": "int", "dimensions": 0},
+              "n": { "type": "int", "dimensions": 0},
+              "X": { "type": "int", "dimensions": 2},
+              "S": { "type": "int", "dimensions": 0} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/multi_occupancy.stan"

--- a/posterior_database/models/info/nes.info.json
+++ b/posterior_database/models/info/nes.info.json
@@ -7,6 +7,14 @@
   },
   "description": "partyid7 ~ real_ideo + race_adj + age30_44 + age45_64 + age65up + educ1 + gender + income",
   "urls": "https://raw.githubusercontent.com/stan-dev/example-models/master/ARM/Ch.4/nes.stan",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "partyid7": { "type": "real", "dimensions": 1},
+              "real_ideo": { "type": "real", "dimensions": 1},
+              "race_adj": { "type": "real", "dimensions": 1},
+              "educ1": { "type": "real", "dimensions": 1},
+              "gender": { "type": "real", "dimensions": 1},
+              "income": { "type": "real", "dimensions": 1},
+              "age_discrete": { "type": "int", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/nes.stan"

--- a/posterior_database/models/info/nn_rbm1bJ10.info.json
+++ b/posterior_database/models/info/nn_rbm1bJ10.info.json
@@ -7,6 +7,11 @@
   },
   "description": "A One Layer Restricted Boltzman Machine Neural Network with added bias and 10 hidden units. The implementation follows that of Lampainen and Vehtari (2001).",
   "urls": "https://github.com/stan-dev/example-models/tree/master/knitr/neural-nets",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "M": { "type": "int", "dimensions": 0},
+              "x": { "type": "real", "dimensions": 2},
+              "K": { "type": "int", "dimensions": 0},
+              "y": { "type": "int", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/nn_rbm1bJ10.stan"

--- a/posterior_database/models/info/nn_rbm1bJ100.info.json
+++ b/posterior_database/models/info/nn_rbm1bJ100.info.json
@@ -7,6 +7,11 @@
   },
   "description": "A One Layer Restricted Boltzman Machine Neural Network with added bias and 100 hidden units. The implementation follows that of Lampainen and Vehtari (2001).",
   "urls": "https://github.com/stan-dev/example-models/tree/master/knitr/neural-nets",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "M": { "type": "int", "dimensions": 0},
+              "x": { "type": "real", "dimensions": 2},
+              "K": { "type": "int", "dimensions": 0},
+              "y": { "type": "int", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/nn_rbm1bJ100.stan"

--- a/posterior_database/models/info/normal_mixture.info.json
+++ b/posterior_database/models/info/normal_mixture.info.json
@@ -7,6 +7,8 @@
   },
   "description": "a gaussian mixture with unknown proportion and means, known variance\np(y|mu,theta) = theta * Normal(y|mu[1],1) + (1-theta) * Normal(y|mu[2],1)",
   "urls": "https://raw.githubusercontent.com/stan-dev/example-models/master/basic_estimators/normal_mixture.stan",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "y": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/normal_mixture.stan"

--- a/posterior_database/models/info/normal_mixture_k.info.json
+++ b/posterior_database/models/info/normal_mixture_k.info.json
@@ -7,6 +7,9 @@
   },
   "description": "a Gaussian mixture with unknown proportions, means and variances",
   "urls": "https://raw.githubusercontent.com/stan-dev/example-models/master/basic_estimators/normal_mixture_k.stan",
+  "inputs": { "K": { "type": "int", "dimensions": 0},
+              "N": { "type": "int", "dimensions": 0},
+              "y": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/normal_mixture_k.stan"

--- a/posterior_database/models/info/one_comp_mm_elim_abs.info.json
+++ b/posterior_database/models/info/one_comp_mm_elim_abs.info.json
@@ -12,6 +12,12 @@
   "prior": {
     "keywords": []
   },
+  "inputs": { "t0": { "type": "real", "dimensions": 0},
+              "D": { "type": "real", "dimensions": 0},
+              "V": { "type": "real", "dimensions": 0},
+              "N_t": { "type": "int", "dimensions": 0},
+              "times": { "type": "real", "dimensions": 1},
+              "C_hat": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/one_comp_mm_elim_abs.stan"

--- a/posterior_database/models/info/pilots.info.json
+++ b/posterior_database/models/info/pilots.info.json
@@ -7,6 +7,12 @@
   },
   "description": "y ~ 1 + (1 | group) + (1 | scenario))",
   "urls": "https://raw.githubusercontent.com/stan-dev/example-models/master/ARM/Ch.14/pilots.stan",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "n_groups": { "type": "int", "dimensions": 0},
+              "n_scenarios": { "type": "int", "dimensions": 0},
+              "group_id": { "type": "int", "dimensions": 1},
+              "scenario_id": { "type": "int", "dimensions": 1},
+              "y": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/pilots.stan"

--- a/posterior_database/models/info/prophet.info.json
+++ b/posterior_database/models/info/prophet.info.json
@@ -7,6 +7,19 @@
   },
   "description": "Structural Time Series Model",
   "urls": "https://raw.githubusercontent.com/facebook/prophet/master/R/inst/stan/prophet.stan",
+  "inputs": { "T": { "type": "int", "dimensions": 0},
+              "K": { "type": "int", "dimensions": 0},
+              "t": { "type": "real", "dimensions": 1},
+              "cap": { "type": "real", "dimensions": 1},
+              "y": { "type": "real", "dimensions": 1},
+              "S": { "type": "int", "dimensions": 0},
+              "t_change": { "type": "real", "dimensions": 1},
+              "X": { "type": "real", "dimensions": 2},
+              "sigmas": { "type": "real", "dimensions": 1},
+              "tau": { "type": "real", "dimensions": 0},
+              "trend_indicator": { "type": "int", "dimensions": 0},
+              "s_a": { "type": "real", "dimensions": 1},
+              "s_m": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/prophet.stan"

--- a/posterior_database/models/info/radon_county.info.json
+++ b/posterior_database/models/info/radon_county.info.json
@@ -7,6 +7,10 @@
   },
   "description": "y ~ (1|county)",
   "urls": "https://raw.githubusercontent.com/bbbales2/cmdstan-warmup/develop/examples/radon/radon.stan",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "J": { "type": "int", "dimensions": 0},
+              "county": { "type": "int", "dimensions": 1},
+              "y": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/radon_county.stan"

--- a/posterior_database/models/info/radon_county_intercept.info.json
+++ b/posterior_database/models/info/radon_county_intercept.info.json
@@ -7,6 +7,11 @@
   },
   "description": "A linear model with different intercepts per county.",
   "urls": "https://mc-stan.org/users/documentation/case-studies/radon.html",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "J": { "type": "int", "dimensions": 0},
+              "county_idx": { "type": "int", "dimensions": 1},
+              "floor_measure": { "type": "real", "dimensions": 1},
+              "log_radon": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/radon_county_intercept.stan"

--- a/posterior_database/models/info/radon_hierarchical_intercept_centered.info.json
+++ b/posterior_database/models/info/radon_hierarchical_intercept_centered.info.json
@@ -7,6 +7,12 @@
   },
   "description": "A linear model with different intercepts per county and county level log_uppm covariate. This model is a centered parametrization.",
   "urls": "https://mc-stan.org/users/documentation/case-studies/radon.html",
+  "inputs": { "J": { "type": "int", "dimensions": 0},
+              "N": { "type": "int", "dimensions": 0},
+              "county_idx": { "type": "int", "dimensions": 1},
+              "log_uppm": { "type": "real", "dimensions": 1},
+              "floor_measure": { "type": "real", "dimensions": 1},
+              "log_radon": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/radon_hierarchical_intercept_centered.stan"

--- a/posterior_database/models/info/radon_hierarchical_intercept_noncentered.info.json
+++ b/posterior_database/models/info/radon_hierarchical_intercept_noncentered.info.json
@@ -7,6 +7,12 @@
   },
   "description": "A linear model with different intercepts per county and county level log_uppm covariate. This model is a non-centered parametrization.",
   "urls": "https://mc-stan.org/users/documentation/case-studies/radon.html",
+  "inputs": { "J": { "type": "int", "dimensions": 0},
+              "N": { "type": "int", "dimensions": 0},
+              "county_idx": { "type": "int", "dimensions": 1},
+              "log_uppm": { "type": "real", "dimensions": 1},
+              "floor_measure": { "type": "real", "dimensions": 1},
+              "log_radon": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/radon_hierarchical_intercept_noncentered.stan"

--- a/posterior_database/models/info/radon_partially_pooled_centered.info.json
+++ b/posterior_database/models/info/radon_partially_pooled_centered.info.json
@@ -7,6 +7,10 @@
   },
   "description": "A linear model with different intercepts per county and a hiearchical prior. This model uses a centered parametrization.",
   "urls": "https://mc-stan.org/users/documentation/case-studies/radon.html",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "J": { "type": "int", "dimensions": 0},
+              "county_idx": { "type": "int", "dimensions": 1},
+              "log_radon": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/radon_partially_pooled_centered.stan"

--- a/posterior_database/models/info/radon_partially_pooled_noncentered.info.json
+++ b/posterior_database/models/info/radon_partially_pooled_noncentered.info.json
@@ -7,6 +7,10 @@
   },
   "description": "A linear model with different intercepts per county and a hiearchical prior. This model is a non-centered parametrization.",
   "urls": "https://mc-stan.org/users/documentation/case-studies/radon.html",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "J": { "type": "int", "dimensions": 0},
+              "county_idx": { "type": "int", "dimensions": 1},
+              "log_radon": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/radon_partially_pooled_noncentered.stan"

--- a/posterior_database/models/info/radon_pooled.info.json
+++ b/posterior_database/models/info/radon_pooled.info.json
@@ -7,6 +7,9 @@
   },
   "description": "A simple pooled linear model.",
   "urls": "https://mc-stan.org/users/documentation/case-studies/radon.html",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "floor_measure": { "type": "real", "dimensions": 1},
+              "log_radon": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/radon_pooled.stan"

--- a/posterior_database/models/info/radon_variable_intercept_centered.info.json
+++ b/posterior_database/models/info/radon_variable_intercept_centered.info.json
@@ -7,6 +7,11 @@
   },
   "description": "A linear model with different intercepts per county, a global regression coefficient, and a hiearchical prior. This model uses a centered parametrization.",
   "urls": "https://mc-stan.org/users/documentation/case-studies/radon.html",
+  "inputs": { "J": { "type": "int", "dimensions": 0},
+              "N": { "type": "int", "dimensions": 0},
+              "county_idx": { "type": "int", "dimensions": 1},
+              "floor_measure": { "type": "real", "dimensions": 1},
+              "log_radon": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/radon_variable_intercept_centered.stan"

--- a/posterior_database/models/info/radon_variable_intercept_noncentered.info.json
+++ b/posterior_database/models/info/radon_variable_intercept_noncentered.info.json
@@ -7,6 +7,11 @@
   },
   "description": "A linear model with different intercepts per county, a global regression coefficient, and a hiearchical prior. This model uses a non-centered parametrization.",
   "urls": "https://mc-stan.org/users/documentation/case-studies/radon.html",
+  "inputs": { "J": { "type": "int", "dimensions": 0},
+              "N": { "type": "int", "dimensions": 0},
+              "county_idx": { "type": "int", "dimensions": 1},
+              "floor_measure": { "type": "real", "dimensions": 1},
+              "log_radon": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/radon_variable_intercept_noncentered.stan"

--- a/posterior_database/models/info/radon_variable_intercept_slope_centered.info.json
+++ b/posterior_database/models/info/radon_variable_intercept_slope_centered.info.json
@@ -7,6 +7,11 @@
   },
   "description": "A linear model with hiearchical intercept and slope coefficients using an hiearchical prior. This model uses a centered parametrization.",
   "urls": "https://mc-stan.org/users/documentation/case-studies/radon.html",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "J": { "type": "int", "dimensions": 0},
+              "county_idx": { "type": "int", "dimensions": 1},
+              "floor_measure": { "type": "real", "dimensions": 1},
+              "log_radon": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/radon_variable_intercept_slope_centered.stan"

--- a/posterior_database/models/info/radon_variable_intercept_slope_noncentered.info.json
+++ b/posterior_database/models/info/radon_variable_intercept_slope_noncentered.info.json
@@ -7,6 +7,11 @@
   },
   "description": "A linear model with hiearchical intercept and slope coefficients using an hiearchical prior. This model uses a non-centered parametrization.",
   "urls": "https://mc-stan.org/users/documentation/case-studies/radon.html",
+  "inputs": { "N": { "type": "int", "dimensions": 0},
+              "J": { "type": "int", "dimensions": 0},
+              "county_idx": { "type": "int", "dimensions": 1},
+              "floor_measure": { "type": "real", "dimensions": 1},
+              "log_radon": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/radon_variable_intercept_slope_noncentered.stan"

--- a/posterior_database/models/info/radon_variable_slope_centered.info.json
+++ b/posterior_database/models/info/radon_variable_slope_centered.info.json
@@ -7,6 +7,11 @@
   },
   "description": "A linear model with a global intercept and different regression coefficients using an hiearchical prior. This model uses a centered parametrization.",
   "urls": "https://mc-stan.org/users/documentation/case-studies/radon.html",
+  "inputs": { "J": { "type": "int", "dimensions": 0},
+              "N": { "type": "int", "dimensions": 0},
+              "county_idx": { "type": "int", "dimensions": 1},
+              "floor_measure": { "type": "real", "dimensions": 1},
+              "log_radon": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/radon_variable_slope_centered.stan"

--- a/posterior_database/models/info/radon_variable_slope_noncentered.info.json
+++ b/posterior_database/models/info/radon_variable_slope_noncentered.info.json
@@ -7,6 +7,11 @@
   },
   "description": "A linear model with a global intercept and different regression coefficients using an hiearchical prior. This model uses a non-centered parametrization.",
   "urls": "https://mc-stan.org/users/documentation/case-studies/radon.html",
+  "inputs": { "J": { "type": "int", "dimensions": 0},
+              "N": { "type": "int", "dimensions": 0},
+              "county_idx": { "type": "int", "dimensions": 1},
+              "floor_measure": { "type": "real", "dimensions": 1},
+              "log_radon": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/radon_variable_slope_noncentered.stan"

--- a/posterior_database/models/info/sir.info.json
+++ b/posterior_database/models/info/sir.info.json
@@ -14,6 +14,11 @@
   "prior": {
     "keywords": []
   },
+  "inputs": { "N_t": { "type": "int", "dimensions": 0},
+              "t": { "type": "real", "dimensions": 1},
+              "y0": { "type": "real", "dimensions": 1},
+              "stoi_hat": { "type": "int", "dimensions": 1},
+              "B_hat": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/sir.stan"

--- a/posterior_database/models/info/soil_incubation.info.json
+++ b/posterior_database/models/info/soil_incubation.info.json
@@ -7,6 +7,11 @@
   },
   "description": "A statistical two-pool model with decomposition rates for each pool\nas well as transfer rates from one pool to another.",
   "urls": "https://github.com/stan-dev/example-models/blob/master/knitr/soil-carbon/soil_incubation.stan",
+  "inputs": { "totalC_t0": { "type": "real", "dimensions": 0},
+              "t0": { "type": "real", "dimensions": 0},
+              "N_t": { "type": "int", "dimensions": 0},
+              "ts": { "type": "real", "dimensions": 1},
+              "eCO2mean": { "type": "real", "dimensions": 1} },
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/soil_incubation.stan"


### PR DESCRIPTION
Thank you for your nice project!

For some posteriors, the data contains more entries than what is expected for the model. For example in `kidiq-kidscore_momiq`:
- the model (`kidscore_momiq`) expects `N`, `kid_score`, and `mom_iq`
- but the data (`kidiq`) also provides `mom_hs`, `mom_hs_new`, and `mom_iq_new`.

In order to pass automatically the correct inputs for the inference, I find useful to have information about the expected inputs of the model.

In this pull request, I have added for each Stan model in the `model.info.json` file an additional field with the information about the expected data. For example, on the `kidscore_momiq` model, now there is the following field:
```
  "inputs": { "N": { "type": "int", "dimensions": 0},
              "kid_score": { "type": "real", "dimensions": 1},
              "mom_iq": { "type": "real", "dimensions": 1} },
```

I also need the expected type to convert the data into the right format. So, I have associated this information to each input.

Thank you for considering this PR. I am happy to change the format if you want.

Best