### PR TITLE
add github database for Python

### DIFF
--- a/.github/workflows/workflow-python.yml
+++ b/.github/workflows/workflow-python.yml
@@ -3,9 +3,9 @@ name: Python
 on:
   push:
     branches:
-      - '*'
+      - '**'
     tags:
-      - '*'
+      - '**'
 
 jobs:
   models:

--- a/.github/workflows/workflow-python.yml
+++ b/.github/workflows/workflow-python.yml
@@ -16,6 +16,8 @@ jobs:
           os: [ubuntu-latest, macos-latest, windows-latest]
           python-version: [3.6, 3.7, 3.8, 3.9]
       fail-fast: false
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout github
         uses: actions/checkout@v2

--- a/.github/workflows/workflow-r.yml
+++ b/.github/workflows/workflow-r.yml
@@ -116,7 +116,7 @@ jobs:
           path: /Users/runner/work/posteriordb/posteriordb/posteriordb.Rcheck/*.log
 
       - name: Codecov
-        if: matrix.config.r == 'release' && runner.os == 'macos-latest')
+        if: (matrix.config.r == 'release') && (runner.os == 'macos-latest')
         run: |
           echo $GITHUB_WORKSPACE
           Rscript -e "covr::codecov(path = 'rpackage', quiet = FALSE)"

--- a/.github/workflows/workflow-r.yml
+++ b/.github/workflows/workflow-r.yml
@@ -3,9 +3,9 @@ name: R
 on:
   push:
     branches:
-      - '*'
+      - '**'
     tags:
-      - '*'
+      - '**'
 
 jobs:
   models:

--- a/python/README.md
+++ b/python/README.md
@@ -4,12 +4,19 @@ Currently only python 3.6+ is supported. Python 3.5+ support can be added if nee
 
 ## Installation
 
-Currently only local install is supported. From the main directory of this project run
+Installation from PyPI is recommended.
+
 ```bash
-pip install python/
+pip install posteriordb
 ```
 
-Installing from git url will be supported soon. Publishing the package to PyPI will also happen at some point.
+Or with a local git clone
+
+```bash
+git clone https://github.com/MansMeg/posteriordb
+cd posteriordb
+pip install python/
+```
 
 ## Using the posterior database from python
 
@@ -23,9 +30,22 @@ First we create the posterior database to use, here the cloned posterior databas
 >>> pdb_path = os.path.join(os.getcwd(), "posterior_database")
 >>> my_pdb = PosteriorDatabase(pdb_path)
 ```
-
 The above code requires that your working directory is in the main folder of your copy
-of this project. Alternatively, you can specify the path to the folder directly. To list the posteriors available, use `posterior_names`.
+of this project. Alternatively, you can specify the path to the folder directly.
+
+To use online database use `PosteriorDatabaseGithub` class. Remember to create and set `GITHUB_PAT` environmental variable.
+It is recommended that users create a read-only Personal Access Token for `posteriordb` use.
+If not explicitly defined, `PosteriorDatabaseGithub` will create a new or use old database located at `POSTERIOR_DB_DIR` if
+defined and `$HOME/.posteriordb/posterior_database`. Each used model and data is downloaded from online dynamically when needed.
+
+```python
+>>> from posteriordb import PosteriorDatabaseGithub
+>>> import os
+>>> os.environ["GITHUB_PAT"] = "token-string-here"
+>>> my_pdb = PosteriorDatabaseGithub()
+```
+
+To list the posteriors available, use `posterior_names`.
 
 ```python
 >>> pos = my_pdb.posterior_names()

--- a/python/README.md
+++ b/python/README.md
@@ -33,13 +33,14 @@ First we create the posterior database to use, here the cloned posterior databas
 The above code requires that your working directory is in the main folder of your copy
 of this project. Alternatively, you can specify the path to the folder directly.
 
-To use online database use `PosteriorDatabaseGithub` class. Remember to create and set `GITHUB_PAT` environmental variable.
-It is recommended that users create a read-only (no extra permissions) [GitHub Personal Access Token (PAT)](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) for `posteriordb` use. It is recommended that the
-GITHUB_PAT variable is added to user environmental variables and it is not set in Python script as shown in the example.
+Online database can be used with the `PosteriorDatabaseGithub` class. Remember to create and set `GITHUB_PAT` environmental variable.
+It's recommended that users create a read-only (no extra permissions) [GitHub Personal Access Token (PAT)](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) for `posteriordb` use. It's also recommended that the
+`GITHUB_PAT` environmental variable is added to user environmental variables and it is not shown in Python script as in the example below.
 
 
-If not explicitly defined, `PosteriorDatabaseGithub` will create a new or use old database located at `POSTERIOR_DB_DIR` if
-defined and `$HOME/.posteriordb/posterior_database`. Each used model and data is downloaded from online dynamically when needed.
+If not explicitly defined, `PosteriorDatabaseGithub` will create a new (or use old database) located at `POSTERIOR_DB_DIR` if it's
+defined and finally as a fallback `$HOME/.posteriordb/posterior_database` is used.
+Each model and data is only downloaded and cached when needed.
 
 ```python
 >>> from posteriordb import PosteriorDatabaseGithub

--- a/python/README.md
+++ b/python/README.md
@@ -38,8 +38,8 @@ It's recommended that users create a read-only (no extra permissions) [GitHub Pe
 `GITHUB_PAT` environmental variable is added to user environmental variables and it is not shown in Python script as in the example below.
 
 
-If not explicitly defined, `PosteriorDatabaseGithub` will create a new (or use old database) located at `POSTERIOR_DB_DIR` if it's
-defined and finally as a fallback `$HOME/.posteriordb/posterior_database` is used.
+If not explicitly defined, `PosteriorDatabase` and `PosteriorDatabaseGithub` will create a new (or use old database) located at `POSTERIOR_DB_PATH` if it's
+defined. `PosteriorDatabaseGithub` will finally use `$HOME/.posteriordb/posterior_database` as a fallback location if no environmental variables have been set.
 Each model and data is only downloaded and cached when needed.
 
 ```python

--- a/python/README.md
+++ b/python/README.md
@@ -34,9 +34,9 @@ The above code requires that your working directory is in the main folder of you
 of this project. Alternatively, you can specify the path to the folder directly.
 
 To use online database use `PosteriorDatabaseGithub` class. Remember to create and set `GITHUB_PAT` environmental variable.
-It is recommended that users create a read-only (no extra permissions) Personal Access Token (PAT) for `posteriordb` use.
+It is recommended that users create a read-only (no extra permissions) [GitHub Personal Access Token (PAT)](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) for `posteriordb` use. It is recommended that the
+GITHUB_PAT variable is added to user environmental variables and it is not set in Python script as shown in the example.
 
-https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token
 
 If not explicitly defined, `PosteriorDatabaseGithub` will create a new or use old database located at `POSTERIOR_DB_DIR` if
 defined and `$HOME/.posteriordb/posterior_database`. Each used model and data is downloaded from online dynamically when needed.
@@ -44,6 +44,8 @@ defined and `$HOME/.posteriordb/posterior_database`. Each used model and data is
 ```python
 >>> from posteriordb import PosteriorDatabaseGithub
 >>> import os
+>>> # It is recommended that GITHUB_PAT is added to the user environmental variables
+>>> # outside python and not in a python script as shown in this example code
 >>> os.environ["GITHUB_PAT"] = "token-string-here"
 >>> my_pdb = PosteriorDatabaseGithub()
 ```

--- a/python/README.md
+++ b/python/README.md
@@ -10,7 +10,7 @@ Installation from PyPI is recommended.
 pip install posteriordb
 ```
 
-Or with a local git clone
+Installing from the local clone.
 
 ```bash
 git clone https://github.com/MansMeg/posteriordb

--- a/python/README.md
+++ b/python/README.md
@@ -34,7 +34,10 @@ The above code requires that your working directory is in the main folder of you
 of this project. Alternatively, you can specify the path to the folder directly.
 
 To use online database use `PosteriorDatabaseGithub` class. Remember to create and set `GITHUB_PAT` environmental variable.
-It is recommended that users create a read-only Personal Access Token for `posteriordb` use.
+It is recommended that users create a read-only (no extra permissions) Personal Access Token (PAT) for `posteriordb` use.
+
+https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token
+
 If not explicitly defined, `PosteriorDatabaseGithub` will create a new or use old database located at `POSTERIOR_DB_DIR` if
 defined and `$HOME/.posteriordb/posterior_database`. Each used model and data is downloaded from online dynamically when needed.
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -4,6 +4,12 @@ from setuptools import setup
 
 PROJECT_ROOT = os.path.dirname(os.path.realpath(__file__))
 VERSION_FILE = os.path.join(PROJECT_ROOT, "src", "posteriordb", "__init__.py")
+README_FILE = os.path.join(PROJECT_ROOT, "README.md")
+
+
+def get_long_description():
+    with open(README_FILE, "rt") as buff:
+        return buff.read()
 
 
 def get_version():
@@ -24,6 +30,8 @@ setup(
     author="Eero Linna",
     author_email="eero.linna@aalto.fi",
     license="GPL",
+    long_description=get_long_description(),
+    long_description_content_type="text/markdown",
     packages=["posteriordb"],
     package_dir={"": "src"},
     zip_safe=False,

--- a/python/setup.py
+++ b/python/setup.py
@@ -34,5 +34,6 @@ setup(
     long_description_content_type="text/markdown",
     packages=["posteriordb"],
     package_dir={"": "src"},
+    install_requires=["requests"],
     zip_safe=False,
 )

--- a/python/setup.py
+++ b/python/setup.py
@@ -5,6 +5,7 @@ from setuptools import setup
 PROJECT_ROOT = os.path.dirname(os.path.realpath(__file__))
 VERSION_FILE = os.path.join(PROJECT_ROOT, "src", "posteriordb", "__init__.py")
 
+
 def get_version():
     lines = open(VERSION_FILE, "rt").readlines()
     version_regex = r"^__version__ = ['\"]([^'\"]*)['\"]"
@@ -13,6 +14,7 @@ def get_version():
         if mo:
             return mo.group(1)
     raise RuntimeError("Unable to find version in %s." % (VERSION_FILE,))
+
 
 setup(
     name="posteriordb",

--- a/python/src/posteriordb/__init__.py
+++ b/python/src/posteriordb/__init__.py
@@ -1,3 +1,4 @@
 from .posterior_database import PosteriorDatabase
+from .posterior_database_github import PosteriorDatabaseGithub
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/python/src/posteriordb/dataset.py
+++ b/python/src/posteriordb/dataset.py
@@ -1,14 +1,18 @@
 import json
 import os
 import tempfile
+from typing import Union
 from zipfile import ZipFile
 
 from .posterior_database import PosteriorDatabase
+from .posterior_database_github import PosteriorDatabaseGithub
 from .util import drop_keys
 
 
 class Dataset:
-    def __init__(self, name: str, posterior_db: PosteriorDatabase):
+    def __init__(
+        self, name: str, posterior_db: Union[PosteriorDatabase, PosteriorDatabaseGithub]
+    ):
         self.name = name
         self.posterior_db = posterior_db
         full_information = self.posterior_db.get_data_info(name=self.name)

--- a/python/src/posteriordb/model.py
+++ b/python/src/posteriordb/model.py
@@ -1,6 +1,8 @@
 import os
+from typing import Union
 
 from .posterior_database import PosteriorDatabase
+from .posterior_database_github import PosteriorDatabaseGithub
 from .pymc3_model_implementation import PyMC3ModelImplementation
 from .stan_model_implementation import StanModelImplementation
 from .util import drop_keys
@@ -9,7 +11,9 @@ implementations = {"stan": StanModelImplementation, "pymc3": PyMC3ModelImplement
 
 
 class Model:
-    def __init__(self, name: str, posterior_db: PosteriorDatabase):
+    def __init__(
+        self, name: str, posterior_db: Union[PosteriorDatabase, PosteriorDatabaseGithub]
+    ):
         self.name = name
         self.posterior_db = posterior_db
         full_model_info = self.posterior_db.get_model_info(name=self.name)

--- a/python/src/posteriordb/posterior.py
+++ b/python/src/posteriordb/posterior.py
@@ -1,15 +1,19 @@
 import json
+from typing import Union
 from zipfile import ZipFile
 
 from .dataset import Dataset
 from .model import Model
 from .posterior_database import load_json_file
 from .posterior_database import PosteriorDatabase
+from .posterior_database_github import PosteriorDatabaseGithub
 from .util import drop_keys
 
 
 class Posterior:
-    def __init__(self, name: str, posterior_db: PosteriorDatabase):
+    def __init__(
+        self, name: str, posterior_db: Union[PosteriorDatabase, PosteriorDatabaseGithub]
+    ):
         self.name = name
 
         assert name in posterior_db.posterior_names()

--- a/python/src/posteriordb/posterior.py
+++ b/python/src/posteriordb/posterior.py
@@ -4,7 +4,6 @@ from zipfile import ZipFile
 
 from .dataset import Dataset
 from .model import Model
-from .posterior_database import load_json_file
 from .posterior_database import PosteriorDatabase
 from .posterior_database_github import PosteriorDatabaseGithub
 from .util import drop_keys

--- a/python/src/posteriordb/posterior_database.py
+++ b/python/src/posteriordb/posterior_database.py
@@ -32,8 +32,10 @@ def filenames_in_dir_no_extension(directory, extension):
 
 
 class PosteriorDatabase:
-    def __init__(self, path: str):
-        self.path = path
+    def __init__(self, path: str = None):
+        if path is None:
+            path = os.environ.get("POSTERIOR_DB_PATH")
+        self.path = str(path)
         # TODO assert that path is a valid posterior database
 
     def full_path(self, path: str):

--- a/python/src/posteriordb/posterior_database_github.py
+++ b/python/src/posteriordb/posterior_database_github.py
@@ -1,0 +1,270 @@
+import json
+import os
+import tempfile
+from pathlib import Path
+import requests
+
+
+def temporary_no_assertions(x):
+    return x
+
+
+def get_requests(*args, n=3, **kwargs):
+    for _ in range(n):
+        try:
+            response = requests.get(*args, **kwargs)
+            if response.ok:
+                break
+        except Exception as e:
+            print(e)
+            continue
+    else:
+        print("response:", response.json())
+        raise ValueError("response was not successful")
+    return response
+
+
+def github_pat():
+    GITHUB_PAT = os.environ.get("GITHUB_PAT")
+    headers = {}
+    if GITHUB_PAT is not None:
+        headers["Authorization"] = "token {}".format(GITHUB_PAT)
+    else:
+        print(
+            "GitHub access token was not defined (env GITHUB_PAT not defined), using limited API rate limit."
+        )
+    return headers
+
+
+def get_content(url, path=None, headers=None):
+    """Download contents assuming GitHub API v3"""
+
+    if headers is None:
+        headers = github_pat()
+    if path is not None:
+        path = Path(path)
+    verify = os.environ.get("REQUESTS_VERIFY", True)
+    if str(verify).lower() in ("0", "false"):
+        verify = False
+    verify = bool(verify)
+
+    response = get_requests(url, verify=verify, headers=headers)
+    contents = {}
+
+    for content in response.json():
+        try:
+            if content["type"] == "dir":
+                contents.update(
+                    get_content(content["_links"]["self"], path=path, headers=headers)
+                )
+            else:
+                if path:
+                    key = path / content["path"]
+                else:
+                    key = content["path"]
+                contents[key] = content
+        except Exception as e:
+            print("Invalid content:", content, "Exception was raised (and ignored):", e)
+            continue
+    return contents
+
+
+def download_file(url, path):
+    """Download file with a requests.
+
+    To manually disable requests verify
+    set environmental variable REQUESTS_VERIFY to false.
+    """
+    verify = os.environ.get("REQUESTS_VERIFY", True)
+    if str(verify).lower() in ("0", "false"):
+        verify = False
+    verify = bool(verify)
+
+    headers = github_pat()
+    try:
+        response = get_requests(url, verify=verify, headers=headers)
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        with path.open(mode="wb") as f:
+            f.write(response.content)
+    except Exception as e:
+        print("Exception was raised (and ignored):", e)
+        return False
+    return True
+
+
+def load_json_file(path, metadata):
+    if not path.exists():
+        if metadata is not None:
+            download_file(metadata["download_url"], path)
+        else:
+            raise TypeError("File was not found in GitHub")
+    with path.open(encoding="utf-8") as f:
+        data = json.load(f)
+    return data
+
+
+def load_info(path, assertion_function, metadata):
+    info = load_json_file(path, metadata)
+    assertion_function(info)
+    return info
+
+
+def filenames_in_dir_no_extension(directory, gh_directory, extension):
+    path = Path(directory)
+
+    filenames = [p.with_suffix("").stem for p in path.glob("*" + extension)]
+    gh_filenames = [p.with_suffix("").stem for p in gh_directory]
+    return sorted(set(filenames + gh_filenames))
+
+
+class PosteriorDatabaseGithub:
+    def __init__(
+        self, path: str = None, repo="MansMeg/posteriordb", ref="master", refresh=True
+    ):
+        if path is None:
+            path = os.environ.get("POSTERIOR_DB_DIR")
+            if path is None:
+                path = Path.home() / ".posteriordb" / "posterior_database"
+                path.mkdir(parents=True, exist_ok=True)
+        self.path = Path(path)
+
+        self._url = "https://api.github.com/repos/{repo}/contents/posterior_database?ref={ref}".format(
+            repo=repo, ref=ref
+        )
+        if refresh_github:
+            self.refresh_github()
+        else:
+            self.links = {}
+
+        # TODO assert that path is a valid posterior database
+
+    def refresh_github(self):
+        self._links = get_content(self._url, path=self.path.parent)
+
+    def full_path(self, path: str):
+        return self.path / path
+
+    def posterior(self, name):
+        # inline import needed to avoid import loop
+        from .posterior import Posterior
+
+        return Posterior(name, self)
+
+    def model(self, name):
+        # inline import needed to avoid import loop
+        from .model import Model
+
+        return Model(name, self)
+
+    def data(self, name):
+        # inline import needed to avoid import loop
+        from .dataset import Dataset
+
+        return Dataset(name, self)
+
+    def posterior_info_path(self, name: str):
+        path = self.path / "posteriors" / (name + ".json")
+        return path
+
+    def get_posterior_info(self, name: str):
+        path = self.posterior_info_path(name)
+        return load_info(path, temporary_no_assertions, self._links.get(path))
+
+    def get_model_info(self, name: str):
+        # load from the correct path
+        file_name = name + ".info.json"
+        path = self.path / "models" / "info" / file_name
+
+        return load_info(path, temporary_no_assertions, self._links.get(path))
+
+    def get_data_info(self, name: str):
+        file_name = name + ".info.json"
+        path = self.path / "data" / "info" / file_name
+
+        return load_info(path, temporary_no_assertions, self._links.get(path))
+
+    def get_reference_draws_path(self, name: str):
+        reference_root = self.path / "reference_posteriors" / "draws" / "draws"
+        reference_name = self.get_posterior_info(name).get("reference_posterior_name")
+        assert reference_name is not None
+        path = reference_root / (reference_name + ".json")
+        return path
+
+    def get_reference_draws_info(self, name: str):
+        reference_root = self.path / "reference_posteriors" / "draws" / "info"
+        reference_name = self.get_posterior_info(name).get("reference_posterior_name")
+        assert reference_name is not None
+        path = reference_root / (reference_name + ".info.json")
+        return load_info(path, temporary_no_assertions, self._links.get(path, None))
+
+    def get_model_code_path(self, name, framework):
+        model_info = self.get_model_info(name)
+        path_within_posterior_db = model_info["model_implementations"][framework][
+            "model_code"
+        ]
+        path = self.path / path_within_posterior_db
+
+        # download model code
+        if not path.exists():
+            download_file(self._links[path]["download_url"], path)
+
+        return path
+
+    def get_dataset_path(self, name):
+        data_info = self.get_data_info(name)
+        path = self.path / (data_info["data_file"] + ".zip")
+
+        # download model code
+        if not path.exists():
+            download_file(self._links[path]["download_url"], path)
+
+        return path
+
+    def posterior_names(self):
+        directory = self.path / "posteriors"
+        # walk directory, find json files
+        # strip file extension
+        gh_directory = [
+            key for key in self._links if str(directory.resolve()) in str(key.resolve())
+        ]
+        return filenames_in_dir_no_extension(directory, gh_directory, ".json")
+
+    def model_names(self):
+        directory = self.path / "models" / "info"
+        gh_directory = [
+            key for key in self._links if str(directory.resolve()) in str(key.resolve())
+        ]
+        return filenames_in_dir_no_extension(directory, gh_directory, ".info.json")
+
+    def dataset_names(self):
+        directory = self.path / "data" / "info"
+        gh_directory = [
+            key for key in self._links if str(directory.resolve()) in str(key.resolve())
+        ]
+        return filenames_in_dir_no_extension(directory, gh_directory, ".info.json")
+
+    def posteriors(self):
+        names = self.posterior_names()
+        # inline import needed to avoid import loop
+        from .posterior import Posterior
+
+        for name in names:
+            yield Posterior(name, self)
+
+    def models(self):
+        names = self.model_names()
+        # inline import needed to avoid import loop
+        from .model import Model
+
+        for name in names:
+            yield Model(name, self)
+
+    def datasets(self):
+        names = self.dataset_names()
+        # inline import needed to avoid import loop
+        from .dataset import Dataset
+
+        for name in names:
+            yield Dataset(name, self)

--- a/python/src/posteriordb/posterior_database_github.py
+++ b/python/src/posteriordb/posterior_database_github.py
@@ -149,7 +149,7 @@ class PosteriorDatabaseGithub:
         overwrite=False,
     ):
         if path is None:
-            path = os.environ.get("POSTERIOR_DB_DIR")
+            path = os.environ.get("POSTERIOR_DB_PATH")
             if path is None:
                 path = Path.home() / ".posteriordb" / "posterior_database"
                 path.mkdir(parents=True, exist_ok=True)

--- a/python/tests/test_pdb.py
+++ b/python/tests/test_pdb.py
@@ -1,6 +1,6 @@
 import os
 
-from posteriordb import PosteriorDatabase
+from posteriordb import PosteriorDatabase, PosteriorDatabaseGithub
 
 
 def test_posterior_database():
@@ -8,6 +8,67 @@ def test_posterior_database():
     project_path = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
     pdb_path = os.path.join(project_path, "posterior_database")
     pdb = PosteriorDatabase(pdb_path)
+
+    model_names = pdb.model_names()
+    assert len(model_names) > 0
+
+    dataset_names = pdb.dataset_names()
+    assert len(dataset_names) > 0
+
+    posterior_names = pdb.posterior_names()
+
+    assert len(posterior_names) > 0
+
+    for name in posterior_names:
+        posterior = pdb.posterior(name)
+
+        assert posterior.name is not None
+
+        # test dataset methods
+        data = posterior.data
+        assert data.name is not None
+
+        assert data.values() is not None
+        assert data.file_path() is not None
+
+        assert data.information is not None
+
+        # test that pdb.data works
+        data2 = pdb.data(data.name)
+        assert data2 is not None
+
+        # test model methods
+        model = posterior.model
+
+        assert model.name is not None
+
+        assert model.code("stan") is not None
+        assert model.code_file_path("stan") is not None
+        assert model.stan_code() is not None
+        assert model.stan_code_file_path() is not None
+
+        assert model.information is not None
+
+        # test that pdb.model works
+        model2 = pdb.model(model.name)
+        assert model2 is not None
+
+    posteriors = list(pdb.posteriors())
+    assert len(posteriors) > 0
+
+    models = list(pdb.models())
+    assert len(models) > 0
+
+    datasets = list(pdb.datasets())
+    assert len(datasets) > 0
+
+
+def test_posterior_database_github():
+    # Skip test if GITHUB_PAT not defined
+    if "GITHUB_PAT" not in os.environ:
+        return
+
+    pdb = PosteriorDatabaseGithub()
 
     model_names = pdb.model_names()
     assert len(model_names) > 0

--- a/python/tests/test_pdb.py
+++ b/python/tests/test_pdb.py
@@ -2,6 +2,7 @@ import os
 import re
 
 from posteriordb import PosteriorDatabase, PosteriorDatabaseGithub
+from posteriordb.posterior_database_github import get_sha1_hash
 
 
 def test_posterior_database():
@@ -120,6 +121,18 @@ def test_posterior_database_github():
         # test that pdb.model works
         model2 = pdb.model(model.name)
         assert model2 is not None
+
+        # check sha1
+        ((model_file_path, sha1_github),) = [
+            (key, item["sha"])
+            for key, item in pdb._links.items()
+            if (
+                (key.with_suffix("").stem == model.name)
+                and ("/models/" in key.as_posix())
+            )
+        ]
+        sha1_file = get_sha1_hash(model_file_path)
+        assert sha1_file == sha1_github
 
     posteriors = list(pdb.posteriors())
     assert len(posteriors) > 0

--- a/python/tests/test_pdb.py
+++ b/python/tests/test_pdb.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 from posteriordb import PosteriorDatabase, PosteriorDatabaseGithub
 
@@ -65,10 +66,16 @@ def test_posterior_database():
 
 def test_posterior_database_github():
     # Skip test if GITHUB_PAT not defined
-    if "GITHUB_PAT" not in os.environ:
+    if os.environ.get("GITHUB_PAT") is None:
         return
 
-    pdb = PosteriorDatabaseGithub()
+    kwargs = {}
+    if os.environ.get("GITHUB_ACTIONS"):
+        kwargs["repo"] = os.environ.get("GITHUB_REPOSITORY", "MansMeg/posteriordb")
+        kwargs["ref"] = re.sub(
+            "^refs/heads/", "", os.environ.get("GITHUB_REF", "master")
+        )
+    pdb = PosteriorDatabaseGithub(**kwargs)
 
     model_names = pdb.model_names()
     assert len(model_names) > 0

--- a/python/tests/test_pdb.py
+++ b/python/tests/test_pdb.py
@@ -68,6 +68,8 @@ def test_posterior_database():
 def test_posterior_database_github():
     # Skip test if GITHUB_PAT not defined
     if os.environ.get("GITHUB_PAT") is None:
+        if os.environ.get("CI"):
+            raise TypeError("GITHUB_PAT environmental variable is missing")
         return
 
     kwargs = {}

--- a/python/tests/test_pdb.py
+++ b/python/tests/test_pdb.py
@@ -123,7 +123,7 @@ def test_posterior_database_github():
         assert model2 is not None
 
         # check sha1
-        ((model_file_path, sha1_github),) = [
+        model_files = [
             (key, item["sha"])
             for key, item in pdb._links.items()
             if (
@@ -131,8 +131,9 @@ def test_posterior_database_github():
                 and ("/models/" in key.as_posix())
             )
         ]
-        sha1_file = get_sha1_hash(model_file_path)
-        assert sha1_file == sha1_github
+        for model_file_path, sha1_github in model_files:
+            sha1_file = get_sha1_hash(model_file_path)
+            assert sha1_file == sha1_github
 
     posteriors = list(pdb.posteriors())
     assert len(posteriors) > 0

--- a/rpackage/R/pdb_github.R
+++ b/rpackage/R/pdb_github.R
@@ -155,8 +155,8 @@ github_ref <- function(pdb = NULL) {
   ref <- Sys.getenv("GITHUB_REF")
   if (nzchar(ref)) {
     # This is to handle that GITHUB_REF on Github Actions return 'refs/heads/[ref]'
-    ref <- strsplit(ref, "/")[[1]]
-    return(ref[length(ref)])
+    ref <- sub("^refs/heads/", "", ref)
+    return(ref)
   } else {
     return("master")
   }


### PR DESCRIPTION
This PR adds `PosteriorDatabaseGithub` class that downloads files from GitHub when needed. The class is similar with the `PosteriorDatabase`, but has `.refresh_github` method to manually update the filelist.

Also the init takes repo and ref info. Maybe these could also be class variables (let's see).

The default database location is POSTERIOR_DB_DIR and if it is not defined, it uses `$HOME/.posteriordb/posterior_database`.

It uses GITHUB_PAT, but if it is not defined, it is limited to 60 calls/h. Currently, I have not optimized the number of API calls, but I think users can at least get a few posteriors without the token. There is probably room for improvement here.